### PR TITLE
feat: WS2c CryptoPanic 自备 key——dshtrading.news.cryptoPanicKey + B 源增强降级（#4）

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-30-crypto-news-byok.md
+++ b/.agents/notes/implemented/feature/2026-08-30-crypto-news-byok.md
@@ -1,0 +1,49 @@
+# Agent Note: CryptoPanic 自备 key（WS2c）——B 源增强 + 降级为常态路径
+
+Status: implemented
+
+## Problem
+
+WS2c（docs/analysis-roadmap.md #4）要给新闻工具加用户自备 key：settings `dshtrading.news.cryptoPanicKey`（可选字段），
+有 key 时 `crypto_get_news` 走 CryptoPanic 免费层（B 增强），无 key 优雅降级到 WS2b 公共源并在输出注明。
+前置 #3 的 `crypto_get_news`（见 [[2026-08-30-crypto-get-news]]）。而 spike（PR #7）实测 CryptoPanic 在本出口
+**不可用**（免费路径 404 退役、legacy 403、api 网关子域 TLS 重置），因此必须回答：B 源如何在不依赖本出口可达
+的前提下落地，并保证降级是常态路径而非异常。
+
+## Decision
+
+- **settings 字段注册在既有 `dshtrading` 命名空间**：扩展 `@dsh-trading/router`（该命名空间的 owner）的 Config
+  schema，加 `news: { cryptoPanicKey?: string }`（`installSettingsSection` 复用，用户层赢、base 默认空 = 无 key）。
+  在 `MarketRouterService` 上加 `newsKey()` 访问器（settings resolved 值）。不加独立 `news` settings plugin——
+  这个命名空间就是 dshtrading 的一级配置，新闻 key 与市场 provider 同属用户设置，一份 schema 一处 owner。
+- **kit 工具经 host 面 router 服务读 key**：kit-crypto `apply` 用 `ctx.get('tradingMarketRouter').newsKey()`（scope
+  链向上解析，与连接器读路由同规则；router 缺席 → 无 key → 公共源）。applies:'restart' 语义——apply 时读一次，
+  新建会话生效（与 provider 路由口径一致）。
+- **CryptoPanic 为 B 增强，fed 进 `crypto_get_news` 的源列表**：有 key → 加 `fetchCryptoPanicNews`（`{results:[...]}`，
+  `published_at`/`url`/`title`）；失败 → 落入 `Promise.allSettled` rejected 分支 → `unavailable` 注明（fail-soft），
+  A 级公共源照常返回。**降级（含本出口必现的 CryptoPanic 失败）就是常态路径，不是异常路径**——这与 spike 结论一致。
+- **settings UI 行**：`dshtrading.market.tab` crypto 面板加 CryptoPanic API Key 输入（password 输入 + 保存/放弃 +
+  revision-fenced `scope.mutate`，`['news','cryptoPanicKey']` path；空串 = unset 回公共源）。复用既有 section 机制，
+  locale zh/en 双语。
+
+## Alternatives considered
+
+- **独立 `@dsh-trading/news-settings` 插件注册 news 命名空间**：落选——dshtrading 是市场/交易用户设置的一级
+  namespace，一个 key 字段不值得另起一个 owner；多 owner 会破坏「命名空间一份 schema 一处 owner」的既有契约。
+- **有 key 时用 CryptoPanic 完全替换公共源**：落选——roadmap Q3 定稿「A 打底 + B 增强」，B 是增强不是替换；
+  且本出口 CryptoPanic 不可达，替换会让该出口下的无 key 用户功能受损。
+- **本轮不做 settings UI（只留 schema）**：落选——issue #4 验收含「settings UI 展示该字段」；既有的 crypto 面板
+  加一行是低风险增量（复用 controller + panel save/discard + revision 模式）。
+- **CryptoPanic 活路径本出口验证**：未实现——本出口 TLS 重置无法端到端确认（api 子域握手即断）。活路径按文档
+  形实现 + mock 全测；降级（本出口必现）已 live 实测（假 key → cryptopanic 404 → 公共源照常返回）。留待外部出口
+  /真 key 复验后确认。
+
+## Consequences
+
+- `dshtrading.news.cryptoPanicKey` 可经 `~/.dsh/settings.yaml` 或 settings UI 设置；无 key（默认）时 `crypto_get_news`
+  行为与 WS2b 完全一致（公共源，无 B 源）。
+- CryptoPanic 主路径编码 + mock 两态单测（有 key → B 源被聚合、失败 → unavailable 注明 + 公共源照常）；降级 live
+  实测通过。活跃活路径（CryptoPanic 真实响应）未在本出口验证——需外部可访问出口/真实 key 补验（写入
+  `spikes/impl-crypto-news/EVIDENCE.md` §CryptoPanic 的结论，关联 WS2c）。
+- 全量 `pnpm -r build`/`-r test` 门禁由 PR CI 承接；本地已对 router（14 例）、kit-crypto（16 例）、client-ui-settings
+  （5 例 + 双 tsdown 构建）验证。

--- a/packages/client-ui-settings/src/client/MarketProviderPanel.tsx
+++ b/packages/client-ui-settings/src/client/MarketProviderPanel.tsx
@@ -30,6 +30,10 @@ export interface MarketProviderPanelInjected {
   setProvider: (market: string, provider: string) => Promise<void>
   /** Write path: clear this market's provider (re-inherit base default). */
   resetProvider: (market: string) => Promise<void>
+  /** WS2c: write/clear the CryptoPanic news API key (empty = clear → public sources). */
+  setNewsKey: (value: string) => Promise<void>
+  /** WS2c: clear the CryptoPanic news API key back to base (public sources). */
+  resetNewsKey: () => Promise<void>
 }
 
 export type MarketProviderPanelProps =
@@ -37,8 +41,8 @@ export type MarketProviderPanelProps =
   & PropsLocale<'dshtrading.settings'>
   & InjectFace<MarketProviderPanelInjected>
 
-/** Render one market's provider radio group with save/reset. */
-export function MarketProviderPanel({ t, useController, market, setProvider, resetProvider }: MarketProviderPanelProps) {
+/** Render one market's provider radio group with save/reset (+ WS2c news key, crypto only). */
+export function MarketProviderPanel({ t, useController, market, setProvider, resetProvider, setNewsKey, resetNewsKey }: MarketProviderPanelProps) {
   const state = useController((value: TradingSettingsState) => value)
   const resolved = state.resolved[market]
   const overridden = state.overridden[market]
@@ -61,6 +65,38 @@ export function MarketProviderPanel({ t, useController, market, setProvider, res
   }, [draft, resolved, overridden])
 
   const writable = state.writable
+
+  // WS2c：CryptoPanic key（仅 crypto 市场展示）。qwerty draft 当前解析值初始化。
+  const [newsDraft, setNewsDraft] = useState<string | undefined>(undefined)
+  const [newsSaving, setNewsSaving] = useState(false)
+  const [newsMessage, setNewsMessage] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    if (newsDraft === undefined && state.status === 'ready') {
+      setNewsDraft(state.newsKey)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.status, state.newsKey])
+
+  async function saveNews() {
+    setNewsSaving(true)
+    setNewsMessage(undefined)
+    try {
+      const next = (newsDraft ?? '').trim()
+      const current = state.newsKey ?? ''
+      if (next !== current) {
+        await setNewsKey(next) // 空串 = 清除 → 公共源
+      } else if (state.newsOverridden) {
+        await resetNewsKey()
+      }
+      setNewsMessage(t('newsSaved'))
+    } catch (error) {
+      setNewsMessage(`${t('newsSaveFailed')}: ${String((error as { message?: string })?.message ?? error)}`)
+    } finally {
+      setNewsSaving(false)
+    }
+  }
+
+  const newsDirty = (newsDraft === undefined ? state.newsKey ?? '' : newsDraft.trim()) !== (state.newsKey ?? '')
 
   // 开放词汇（2026-08-30 整改 #4）：schema 不拒未知 slug——若存储值不在内置
   // 候选里（第三方连接器），追加一个「自定义」选项让用户看到并能改回已知项，
@@ -124,6 +160,32 @@ export function MarketProviderPanel({ t, useController, market, setProvider, res
         </button>
         {message !== undefined ? <span>{message}</span> : null}
       </div>
+      {market === 'crypto' && (
+        <div style={{ marginTop: 16, borderTop: '1px solid var(--dsw-alias-border-l2, #eee)', paddingTop: 12 }}>
+          <p style={{ margin: '4px 0' }}>{t('newsKeyLabel')}</p>
+          <input
+            type="password"
+            value={newsDraft ?? ''}
+            disabled={!writable || newsSaving}
+            onChange={(event) => setNewsDraft(event.target.value)}
+            placeholder={t('newsKeyPlaceholder')}
+            style={{ width: '100%', maxWidth: 360 }}
+          />
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginTop: 8 }}>
+            <button type="button" disabled={!newsDirty || newsSaving || !writable} onClick={() => void saveNews()}>
+              {t('save')}
+            </button>
+            <button
+              type="button"
+              disabled={newsSaving || !newsDirty}
+              onClick={() => { setNewsDraft(undefined); setNewsMessage(undefined) }}
+            >
+              {t('discard')}
+            </button>
+            {newsMessage !== undefined ? <span>{newsMessage}</span> : null}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/client-ui-settings/src/client/index.ts
+++ b/packages/client-ui-settings/src/client/index.ts
@@ -54,6 +54,18 @@ export function apply(ctx: ClientContext): void {
       const rev = scope.getSnapshot().revision
       await scope.mutate([{ op: 'unset', path: ['markets', market, 'provider'] }], rev)
     },
+    async setNewsKey(value) {
+      const rev = scope.getSnapshot().revision
+      // 空串 = 清除（unset 回 base 默认）：无 key = 新闻走公共源。
+      const op = value.trim()
+        ? { op: 'set' as const, path: ['news', 'cryptoPanicKey'], value: value.trim() }
+        : { op: 'unset' as const, path: ['news', 'cryptoPanicKey'] }
+      await scope.mutate([op], rev)
+    },
+    async resetNewsKey() {
+      const rev = scope.getSnapshot().revision
+      await scope.mutate([{ op: 'unset', path: ['news', 'cryptoPanicKey'] }], rev)
+    },
   }
 
   // Tab ledger read + locale revision (官方 sectionInjected 模式).
@@ -138,6 +150,10 @@ function dictionaries() {
       'current': '当前：{{provider}}',
       'default': '默认',
       'custom': '自定义（{{provider}}，由第三方连接器提供）',
+      'newsKeyLabel': 'CryptoPanic API Key（可选）——新闻工具 crypto_get_news 的 B 增强源；留空则用公共源。',
+      'newsKeyPlaceholder': '粘贴 CryptoPanic free API token（私钥，仅本地存储）',
+      'newsSaved': '已保存',
+      'newsSaveFailed': '保存失败',
       'market.crypto': '加密货币',
       'market.us': '美国股票',
       'market.cn': '中国 A 股',
@@ -155,6 +171,10 @@ function dictionaries() {
       'current': 'Current: {{provider}}',
       'default': 'default',
       'custom': 'Custom ({{provider}}, provided by a third-party connector)',
+      'newsKeyLabel': 'CryptoPanic API key (optional) — B-source enrichment for the crypto_get_news tool; leave empty to use public sources.',
+      'newsKeyPlaceholder': 'Paste a CryptoPanic free API token (stored locally only)',
+      'newsSaved': 'Saved',
+      'newsSaveFailed': 'Save failed',
       'market.crypto': 'Crypto',
       'market.us': 'US Stocks',
       'market.cn': 'China A-shares',

--- a/packages/client-ui-settings/src/client/trading-settings-controller.ts
+++ b/packages/client-ui-settings/src/client/trading-settings-controller.ts
@@ -26,6 +26,8 @@ export const PROVIDER_LABELS: readonly Readonly<{ id: string; label: string }>[]
 /** dshtrading namespace 下的值形状（router 侧同步；窄化后的子集契约）。 */
 export interface TradingSettings {
   markets: Record<string, { provider?: string; tradeProvider?: string }>
+  /** WS2c：新闻相关设置（CryptoPanic API token，可选）。 */
+  news?: { cryptoPanicKey?: string }
 }
 
 /** 组件的可观察状态（SnapshotStore 值）：已解析 value + 覆盖标记。 */
@@ -35,6 +37,10 @@ export interface TradingSettingsState {
   resolved: Record<string, string | undefined>
   /** market id → 用户是否覆盖（user 层 presence）。 */
   overridden: Record<string, boolean>
+  /** WS2c：已解析 CryptoPanic key（undefined = 无 key = 新闻走公共源）。 */
+  newsKey: string | undefined
+  /** WS2c：用户是否覆盖了 CryptoPanic key。 */
+  newsOverridden: boolean
   /** 表单可写（mode=host 且 writable）。 */
   writable: boolean
 }
@@ -43,6 +49,9 @@ export interface TradingSettingsState {
 export interface TradingSettingsActions {
   setProvider(market: string, provider: string): Promise<void>
   resetProvider(market: string): Promise<void>
+  /** WS2c：设置/清除 CryptoPanic key（空串 = 清除回公共源）。 */
+  setNewsKey(value: string): Promise<void>
+  resetNewsKey(): Promise<void>
 }
 
 /** 状态转化：从 settings 快照投射为组件的可观察视图。 */
@@ -63,7 +72,18 @@ export function projectSnapshot(snap: SettingsScopeSnapshot<TradingSettings>): T
     resolved[marketId] = value?.markets?.[marketId]?.provider ?? baseMarkets[marketId]?.provider
     overridden[marketId] = user.markets?.[marketId] !== undefined
   }
-  return { status: snap.status, resolved, overridden, writable: snap.writable && snap.mode === 'host' }
+  // WS2c：新闻 key 同理（value 优先、base 兜底；user 层 presence 判 overridden）。
+  const baseNews = (snap.base as TradingSettings | undefined)?.news
+  const news = value?.news ?? baseNews
+  const userNews = ((snap.user ?? {}) as { news?: { cryptoPanicKey?: string } }).news
+  return {
+    status: snap.status,
+    resolved,
+    overridden,
+    newsKey: news?.cryptoPanicKey,
+    newsOverridden: userNews?.cryptoPanicKey !== undefined,
+    writable: snap.writable && snap.mode === 'host',
+  }
 }
 
 /** 从 settings scope 构建 SnapshotStore（getSnapshot 稳定引用 + subscribe 转发）。 */

--- a/packages/kit-crypto/src/index.ts
+++ b/packages/kit-crypto/src/index.ts
@@ -215,7 +215,12 @@ export function apply(ctx: Context, _config: Config): void {
   // WS2b（docs/analysis-roadmap.md #3）：动态新闻工具——kit 内薄工具，直连公共源
   // （spike 推荐：四源均单端点无鉴权，无 connector 契约要素，故不进 dataplane/路由）。
   // 缺省无 key 全程可用；每源独立容错，输出带来源名 + 时间 + 链接（铁律 #5）。
-  registerOnce(createGetNewsTool())
+  // WS2c（#4）：经 host 面 tradingMarketRouter 读设置 news.cryptoPanicKey——有值则
+  // crypto_get_news 加测 CryptoPanic 免费层（B 增强）；无 router / 无 key 即公共源。
+  const router = (ctx as { get?: (key: string) => unknown }).get?.('tradingMarketRouter') as
+    | { newsKey?: () => string | undefined }
+    | undefined
+  registerOnce(createGetNewsTool({ cryptoPanicKey: router?.newsKey?.() }))
 }
 
 /* ── crypto_get_news：动态新闻工具（WS2b，#3） ───────────────────────────────── */
@@ -227,9 +232,12 @@ function renderNewsItem(item: { source: string; title: string; url: string; publ
   return `[${item.source}] ${item.publishedAt}  ${item.title}\n  ${item.url}`
 }
 
-export function createGetNewsTool() {
+export function createGetNewsTool(toolOptions: { cryptoPanicKey?: string } = {}) {
   const description =
     'Get recent crypto news from public no-key sources (Binance listing/delisting/API announcements, OKX announcements, CoinDesk & The Block RSS). '
+    + (toolOptions.cryptoPanicKey
+      ? 'CryptoPanic user key is set — the CryptoPanic free tier is queried as an additional source and degrades gracefully if it fails. '
+      : '')
     + 'Aggregates and sorts newest-first; each item carries source name, publish time and a link for traceability. '
     + 'Optionally filter by symbol (matched against item titles; note media headlines often use asset names like "Bitcoin" rather than tickers) and by a time window. '
     + 'Source failures are tolerated and reported instead of failing the whole call. No credentials required. Distinguish announcements (listing, delisting, regulatory) from opinion (media) when citing.'
@@ -262,14 +270,16 @@ export function createGetNewsTool() {
         symbol: typeof args.symbol === 'string' ? args.symbol : undefined,
         windowHours: typeof args.windowHours === 'number' ? args.windowHours : undefined,
         limit: typeof args.limit === 'number' ? args.limit : undefined,
+        cryptoPanicKey: toolOptions.cryptoPanicKey,
       }
       const { items, unavailable } = await aggregateNews(options)
       if (items.length === 0 && unavailable.length === 0) {
         return 'crypto_get_news: no news items found within the requested window.'
       }
       const symbolNote = options.symbol ? ` symbol=${options.symbol.trim().toUpperCase()} (tokens: ${deriveSymbolTokens(options.symbol).join(', ')})` : ''
+      const keyNote = options.cryptoPanicKey ? ' cryptopanicKey=set (B-source) ' : ''
       const lines = [
-        `crypto_get_news — ${items.length} item(s)${symbolNote}, window=${options.windowHours ?? DEFAULT_NEWS_WINDOW_HOURS}h (newest-first):`,
+        `crypto_get_news — ${items.length} item(s)${symbolNote}${keyNote}, window=${options.windowHours ?? DEFAULT_NEWS_WINDOW_HOURS}h (newest-first):`,
         ...items.map(renderNewsItem),
       ]
       if (unavailable.length > 0) {

--- a/packages/kit-crypto/src/news.ts
+++ b/packages/kit-crypto/src/news.ts
@@ -10,8 +10,8 @@
  * 铁律 #5：输出只带元数据（来源名/标题/链接/发布时间），不取正文，不缓存，不再分发。
  * 每源独立容错：单源失败不炸整体，失败源在 `unavailable` 中注明（工具输出可见），fail-soft。
  */
-/** 已接入的新闻来源（EVIDENCE 分级总表：A 级打底 + 媒体面）。 */
-export type NewsSource = 'binance' | 'okx' | 'coindesk' | 'theblock'
+/** 已接入的新闻来源（EVIDENCE 分级总表：A 级打底/媒体面 + B 级 CryptoPanic 自备 key）。 */
+export type NewsSource = 'binance' | 'okx' | 'coindesk' | 'theblock' | 'cryptopanic'
 
 export interface NewsItem {
   /** 来源名（铁律 #5 的来源标注；同时是「引用给 Agent 可以、再分发不行」的边界提醒落点）。 */
@@ -33,6 +33,8 @@ export interface AggregateNewsOptions {
   fetch?: typeof globalThis.fetch
   /** 注入当前时间戳（ms，测试用）；缺省 Date.now()。 */
   now?: number
+  /** WS2c：CryptoPanic API token。有值时加测 CryptoPanic 免费层（B 增强）；无值 = 仅公共源。 */
+  cryptoPanicKey?: string
 }
 
 export interface AggregateNewsResult {
@@ -47,6 +49,7 @@ const DSHTRADING_API = 'https://www.binance.com/bapi/composite/v1/public/cms/art
 const OKX_ANNOUNCEMENT_URL = 'https://www.okx.com/api/v5/support/announcements'
 const COINDESK_RSS_URL = 'https://www.coindesk.com/arc/outboundfeeds/rss/'
 const THEBLOCK_RSS_URL = 'https://www.theblock.co/rss.xml'
+const CRYPTOPANIC_API_URL = 'https://cryptopanic.com/api/free/v1/posts/'
 
 const DEFAULT_WINDOW_HOURS = 24
 const DEFAULT_LIMIT = 20
@@ -186,6 +189,37 @@ async function fetchRssNews(fetchImpl: typeof globalThis.fetch, source: NewsSour
   return parseRss2(text, source)
 }
 
+/* ── CryptoPanic 免费层（WS2c B 增强；用户自备 key，无 key 或失败即降级） ───────── */
+
+interface CryptoPanicPost {
+  title?: string
+  url?: string
+  published_at?: string
+  currency?: string
+}
+
+/** 解析 CryptoPanic { results:[...] }（公开 free API 响应形）。 */
+export function parseCryptoPanic(data: unknown): NewsItem[] {
+  const results = (data as { results?: CryptoPanicPost[] }).results
+  if (!Array.isArray(results)) throw new Error('cryptopanic: unexpected payload (expected results[])')
+  const items: NewsItem[] = []
+  for (const post of results) {
+    if (!post.title || !post.url) continue
+    const ts = Date.parse(post.published_at ?? '')
+    if (!Number.isFinite(ts)) continue
+    items.push({ source: 'cryptopanic', title: post.title, url: post.url, publishedAt: new Date(ts).toISOString() })
+  }
+  return items
+}
+
+async function fetchCryptoPanicNews(fetchImpl: typeof globalThis.fetch, key: string, currencies: string): Promise<NewsItem[]> {
+  const url = new URL(CRYPTOPANIC_API_URL)
+  url.searchParams.set('auth_token', key)
+  if (currencies) url.searchParams.set('currencies', currencies)
+  const text = await fetchText(url.toString(), fetchImpl, 'cryptopanic')
+  return parseCryptoPanic(JSON.parse(text))
+}
+
 /* ── 聚合：并发取四源 → 时间窗/币种过滤 → 按时间倒序 → 截尾 ──────────────────── */
 
 /** 币种过滤 token 派生：剥离常见报价/后缀（BTCUSDT-SWAP → [BTCUSDT-SWAP, BTC]）。 */
@@ -217,12 +251,21 @@ export async function aggregateNews(options: AggregateNewsOptions = {}): Promise
   const limit = clampNumber(options.limit, DEFAULT_LIMIT, 1, MAX_LIMIT)
   const tokens = deriveSymbolTokens(options.symbol)
 
-  const results = await Promise.allSettled([
+  // WS2c：有 key 时加测 CryptoPanic 免费层（B 增强）；无 key 仅公共源。
+  // cryptopanic 失败不炸整体——落入 allSettled 的 rejected 分支 → unavailable（降级语义）。
+  const fetchers: Promise<NewsItem[]>[] = [
     fetchBinanceNews(fetchImpl),
     fetchOkxNews(fetchImpl),
     fetchRssNews(fetchImpl, 'coindesk', COINDESK_RSS_URL),
     fetchRssNews(fetchImpl, 'theblock', THEBLOCK_RSS_URL),
-  ])
+  ]
+  if (options.cryptoPanicKey && options.cryptoPanicKey.trim()) {
+    // CryptoPanic currencies 参数用币种代码（BTC/ETH/SOL，不含报价后缀）。
+    const currencies = [...new Set(tokens.map((t) => t.replace(/(?:USDT|USDC|BUSD|FDUSD|USD)$/i, '')))].filter(Boolean).join(',')
+    fetchers.push(fetchCryptoPanicNews(fetchImpl, options.cryptoPanicKey.trim(), currencies))
+  }
+
+  const results = await Promise.allSettled(fetchers)
 
   const items: NewsItem[] = []
   const unavailable: string[] = []

--- a/packages/kit-crypto/src/news.ts
+++ b/packages/kit-crypto/src/news.ts
@@ -260,8 +260,13 @@ export async function aggregateNews(options: AggregateNewsOptions = {}): Promise
     fetchRssNews(fetchImpl, 'theblock', THEBLOCK_RSS_URL),
   ]
   if (options.cryptoPanicKey && options.cryptoPanicKey.trim()) {
-    // CryptoPanic currencies 参数用币种代码（BTC/ETH/SOL，不含报价后缀）。
-    const currencies = [...new Set(tokens.map((t) => t.replace(/(?:USDT|USDC|BUSD|FDUSD|USD)$/i, '')))].filter(Boolean).join(',')
+    // CryptoPanic currencies 参数用币种代码（BTC/ETH/SOL，不含报价/合约后缀）。
+    // tokens 含原始串（如 BTCUSDT-SWAP）与 base（BTC）：先剥合约后缀再剥报价段，
+    // 确保 swap 形也归一到币种代码（否则会把 'BTCUSDT-SWAP' 原样发给 CryptoPanic）。
+    const currencies = [...new Set(tokens
+      .map((t) => t.replace(/[-_]?(?:SWAP|PERP|FUTURES|DEFAULT)$/i, ''))
+      .map((t) => t.replace(/(?:USDT|USDC|BUSD|FDUSD|USD)$/i, ''))
+    )].filter(Boolean).join(',')
     fetchers.push(fetchCryptoPanicNews(fetchImpl, options.cryptoPanicKey.trim(), currencies))
   }
 

--- a/packages/kit-crypto/test/news.test.ts
+++ b/packages/kit-crypto/test/news.test.ts
@@ -189,6 +189,21 @@ describe('CryptoPanic（WS2c：有 key B 增强，失败降级）', () => {
     expect(items[0].source).toBe('cryptopanic')
     expect(items[0].url).toBe('https://cryptopanic.com/news/1')
   })
+
+  it('swap 符号：currencies 参数归一到币种代码（BTCUSDT-SWAP → BTC），不含合约后缀', async () => {
+    const fetchImpl = mockFetchByUrl({
+      'binance.com': () => jsonResp(binanceJson),
+      'okx.com': () => jsonResp(okxJson),
+      'coindesk.com': () => textResp(coinDeskRss),
+      'theblock.co': () => textResp(theBlockRss),
+      'cryptopanic.com': () => jsonResp(cryptoPanicJson),
+    })
+    await aggregateNews({ fetch: fetchImpl, now: NOW, symbol: 'BTCUSDT-SWAP', cryptoPanicKey: 'sec_xyz' })
+    const urls = fetchImpl.mock.calls.map((c) => String(c[0]))
+    const panicUrl = urls.find((u) => u.includes('cryptopanic.com')) ?? ''
+    expect(panicUrl).toContain('currencies=BTC')
+    expect(panicUrl).not.toContain('SWAP')
+  })
 })
 
 describe('createGetNewsTool（工具壳）', () => {

--- a/packages/kit-crypto/test/news.test.ts
+++ b/packages/kit-crypto/test/news.test.ts
@@ -7,7 +7,7 @@
  * OKX data[0].details、RSS 2.0 title/link/pubDate）。
  */
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { aggregateNews, parseRss2, deriveSymbolTokens } from '../src/news.ts'
+import { aggregateNews, parseRss2, deriveSymbolTokens, parseCryptoPanic } from '../src/news.ts'
 import { createGetNewsTool } from '../src/index.ts'
 
 const NOW = Date.parse('2026-08-30T20:00:00Z')
@@ -50,6 +50,13 @@ const theBlockRss = `<?xml version="1.0"?><rss xmlns:dc="http://purl.org/dc/elem
   <title>The Block</title>
   <item><title>Layer 1 chain halts mainnet</title><link>https://www.theblock.co/news/1</link><guid>c</guid><pubDate>Sun, 30 Aug 2026 16:00:00 +0000</pubDate></item>
 </channel></rss>`
+
+const cryptoPanicJson = {
+  results: [
+    { title: 'BTC ETF inflows push price', url: 'https://cryptopanic.com/news/1', published_at: '2026-08-30T18:30:00.000Z', currency: 'BTC' },
+    { title: 'Solana outage reported', url: 'https://cryptopanic.com/news/2', published_at: 'bad-date', currency: 'SOL' },
+  ],
+}
 
 function mockFetchByUrl(responses: Record<string, () => Resp>) {
   return vi.fn(async (input: RequestInfo | URL) => {
@@ -146,6 +153,44 @@ describe('deriveSymbolTokens', () => {
   })
 })
 
+describe('CryptoPanic（WS2c：有 key B 增强，失败降级）', () => {
+  const keyOk = () => mockFetchByUrl({
+    'binance.com': () => jsonResp(binanceJson),
+    'okx.com': () => jsonResp(okxJson),
+    'coindesk.com': () => textResp(coinDeskRss),
+    'theblock.co': () => textResp(theBlockRss),
+    'cryptopanic.com': () => jsonResp(cryptoPanicJson),
+  })
+
+  it('有 key：cryptopanic 源被聚合（B 增强），无 key 则不存在', async () => {
+    const withKey = await aggregateNews({ fetch: keyOk(), now: NOW, cryptoPanicKey: 'sec_xyz' })
+    expect(withKey.items.some((i) => i.source === 'cryptopanic')).toBe(true)
+    const withoutKey = await aggregateNews({ fetch: allSourcesOk(), now: NOW })
+    expect(withoutKey.items.some((i) => i.source === 'cryptopanic')).toBe(false)
+  })
+
+  it('有 key 但 cryptopanic 失败 → 降级：unavailable 注明 cryptopanic，公共源照常返回', async () => {
+    const fetchImpl = mockFetchByUrl({
+      'binance.com': () => jsonResp(binanceJson),
+      'okx.com': () => jsonResp(okxJson),
+      'coindesk.com': () => textResp(coinDeskRss),
+      'theblock.co': () => textResp(theBlockRss),
+      'cryptopanic.com': () => failResp(403),
+    })
+    const { items, unavailable } = await aggregateNews({ fetch: fetchImpl, now: NOW, cryptoPanicKey: 'sec_xyz' })
+    expect(unavailable.some((u) => u.includes('cryptopanic'))).toBe(true)
+    expect(items.some((i) => i.source === 'binance')).toBe(true)
+    expect(items.some((i) => i.source === 'coindesk')).toBe(true)
+  })
+
+  it('parseCryptoPanic：解析 results[]，无效 published_at 跳过', () => {
+    const items = parseCryptoPanic(cryptoPanicJson)
+    expect(items).toHaveLength(1)
+    expect(items[0].source).toBe('cryptopanic')
+    expect(items[0].url).toBe('https://cryptopanic.com/news/1')
+  })
+})
+
 describe('createGetNewsTool（工具壳）', () => {
   it('execute 渲染：含来源、时间、链接与 unavailable 注明', async () => {
     // 工具走真实 Date.now() 过滤时间窗：夹具须锚定在「现在」附近（而非固定 NOW 常量），
@@ -170,5 +215,22 @@ describe('createGetNewsTool（工具壳）', () => {
     expect(text).toContain('https://www.binance.com/en/support/announcement/abc123')
     expect(text).toContain('symbol=BTCUSDT')
     expect(text).not.toContain('source(s) unavailable') // 四源全成功，无缺席
+  })
+
+  it('有 key：输出标注 cryptopanicKey=set（B-source 注记），无 key 不加', async () => {
+    const base = Date.now() - 1_800_000
+    const nearBinance = { code: '000000', data: { catalogs: [{ catalogId: 48, articles: [{ id: 1, code: 'abc123', title: 'Binance Will Launch BTCUSDT Perpetual Contract', type: 1, releaseDate: base }] }] } }
+    const nearPanic = { results: [{ title: 'BTC ETF inflows push price', url: 'https://cryptopanic.com/news/1', published_at: new Date(base).toISOString(), currency: 'BTC' }] }
+    const fetchImpl = mockFetchByUrl({
+      'binance.com': () => jsonResp(nearBinance),
+      'cryptopanic.com': () => jsonResp(nearPanic),
+      'coindesk.com': () => textResp(`<rss><channel><item><title>X</title><link>https://cd/x</link><guid>a</guid><pubDate>${new Date(base).toUTCString()}</pubDate></item></channel></rss>`),
+      'theblock.co': () => textResp(`<rss><channel><item><title>Y</title><link>https://tb/y</link><guid>c</guid><pubDate>${new Date(base).toUTCString()}</pubDate></item></channel></rss>`),
+    })
+    vi.stubGlobal('fetch', fetchImpl)
+    const tool = createGetNewsTool({ cryptoPanicKey: 'sec_xyz' })
+    const text = await tool.execute({ windowHours: 24, limit: 10 }) as string
+    expect(text).toContain('cryptopanicKey=set (B-source)')
+    expect(text).toContain('[cryptopanic]')
   })
 })

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -59,9 +59,16 @@ export interface MarketProviderEntry {
   tradeProvider?: string
 }
 
+export interface NewsConfig {
+  /** 可选：CryptoPanic API token（WS2c，#4）。有值时 crypto_get_news 走 CryptoPanic 免费层增强；无值/无效则优雅降级到公共源。 */
+  cryptoPanicKey?: string
+}
+
 export interface Config {
   /** 各市场数据提供方；dict 键开放（新市场 = 新键，schema 零改）。 */
   markets: Record<string, MarketProviderEntry>
+  /** 新闻相关设置（WS2c）：默认无 key（公共源）。 */
+  news?: NewsConfig
 }
 
 export const DEFAULT_MARKETS: Record<string, MarketProviderEntry> = {
@@ -85,6 +92,8 @@ export const Config: Schema<Config> = Schema.object({
   // 不兼容）→ settings resolver 在用户文档缺失时输出完整默认 markets（critical：
   // installSettingsSection 的 resolved 值没有默认时 = {}，路由会判不出任何 provider）。
   markets: Schema.dict(MarketProviderEntrySchema).default({ ...DEFAULT_MARKETS }),
+  // news 可选（WS2c）：默认空对象 = 无 key = 公共源；字段在时 settings UI 可展示/编辑。
+  news: Schema.object({ cryptoPanicKey: Schema.string().default(undefined) }).default({}),
 })
 
 /** settings namespace（kebab-case 品牌化，llm-pi-ai 同款）。 */
@@ -114,6 +123,11 @@ export class MarketRouterService extends Service implements MarketRouterServiceC
   /** 某市场当前激活的 provider slug（settings resolved：用户层赢，缺省 base 默认）。 */
   activeProvider(market: string): string | undefined {
     return this.source().markets[market]?.provider
+  }
+
+  /** WS2c：CryptoPanic API token（settings resolved；缺省 undefined = 无 key = 新闻走公共源）。 */
+  newsKey(): string | undefined {
+    return this.source().news?.cryptoPanicKey
   }
 
   /** 订阅激活变化（settings commit 驱动；restart 型当前仅记录，未来 live 用）。 */
@@ -268,7 +282,10 @@ export function warnUnknownProviders(config: Config, log: LogLike): string[] {
 
 export function apply(ctx: Context, config: Config): void {
   // loader 没写官方 config 合并语义时，dict 无默认 → 这里兜底合并 DEFAULT_MARKETS。
-  const effective: Config = { markets: { ...DEFAULT_MARKETS, ...(config?.markets ?? {}) } }
+  const effective: Config = {
+    markets: { ...DEFAULT_MARKETS, ...(config?.markets ?? {}) },
+    news: config?.news ?? {},
+  }
   const service = new MarketRouterService(ctx, () => effective)
   // 注册表与 router 同 fiber 提供：base patch 行零改动。
   new MarketDataRegistryService(ctx, service)

--- a/packages/router/test/router.test.ts
+++ b/packages/router/test/router.test.ts
@@ -43,6 +43,12 @@ describe('dshtrading schema（用户设置一级）', () => {
     expect(activeProviderOf(ENTRY, 'hk')).toBe('tencent')
   })
 
+  it('news 默认空对象（无 key，WS2c）：resolved 无 key 不炸、newsKey 为 undefined', () => {
+    const resolve = Config as unknown as (value: unknown) => ConfigType
+    const resolved = resolve({ markets: { ...DEFAULT_MARKETS } })
+    expect(resolved.news?.cryptoPanicKey).toBeUndefined()
+  })
+
   it('dict 键开放：新市场（jp）不炸 schema（构造即验证，无 schema 报错）', () => {
     const cfg: ConfigType = { markets: { ...DEFAULT_MARKETS, jp: { provider: 'yahoo' } } }
     expect(activeProviderOf(cfg, 'jp')).toBe('yahoo')
@@ -172,5 +178,13 @@ describe('MarketRouterService（tradingMarketRouter）', () => {
     svc.notify()
     const before = events.length
     expect(events).toHaveLength(before) // dispose 后不再通知
+  })
+
+  it('newsKey：默认无 key（undefined），setSource 后读 resolved 的 news.cryptoPanicKey（WS2c）', () => {
+    const svc = new MarketRouterService(new CordisContext() as never, () => ENTRY)
+    expect(svc.newsKey()).toBeUndefined()
+    const resolved: ConfigType = { markets: { ...DEFAULT_MARKETS }, news: { cryptoPanicKey: 'sec_xxx' } }
+    svc.setSource(() => resolved)
+    expect(svc.newsKey()).toBe('sec_xxx')
   })
 })


### PR DESCRIPTION
**Closes #4（WS2c；依赖 #3 的 `crypto_get_news`——本 PR 叠在 [PR #8](https://github.com/zhu1090093659/dsh-trading/pull/8) 分支上，`#8` 合入后本 PR 基座自动更新）。**

## 交付内容

- **router**：`dshtrading` Config schema 加 `news.cryptoPanicKey`（`installSettingsSection` 复用，用户层赢 / base 默认空 = 无 key）；`MarketRouterService.newsKey()` 访问器。
- **kit-crypto**：`crypto_get_news` 经 host 面 `tradingMarketRouter.newsKey()` 读 key；**有 key → 加测 CryptoPanic 免费层（B 增强），失败 → `unavailable` 注明（fail-soft），无 key → 公共源**（缺省行为 = WS2b 原样）。
- **client-ui-settings**：`dshtrading.market.tab` crypto 面板加 **CryptoPanic API Key** 输入（password + save/discard + revision-fenced `scope.mutate`，空串 = unset 回公共源）；locale zh/en。
- **Agent Note**：feature/2026-08-30-crypto-news-byok。

## 验证

- 单测全绿：router 14 / kit-crypto 16 / client-ui-settings smoke 5；双 tsdown（node + browser）构建通过。
- **降级 live 实测（本出口，假 key）**：`cryptoPanicKey=FAKE` → cryptopanic HTTP 404 → `unavailable` 注明 cryptopanic，**公共源（binance/coindesk/theblock）照常返回 5 条**——降级即常态路径，已实证。
- 两态 mock 单测：有 key → cryptopanic 源被聚合；无 key → 不含 cryptopanic。

## 边界声明（诚实）

- **CryptoPanic 活路径（真实成功响应）本出口不可验证**：spike（PR #7 EVIDENCE）实测 api 网关子域在本出口 TLS 握手被重置、免费路径 404。故活路径按官方文档形（`{results:[{title,url,published_at}]}`）实现 + mock 全测；对外可达出口/真实 key 复验可作后续补充。
- 全量 `pnpm -r build`/`-r test` 由 PR CI 承接（改动为增量、向后兼容）。

@zhu1090093659 请连同 #7（spike 裁决）、#8（WS2b 实现）一起审。