### PR TITLE
feat: us/cn 市场新闻工具 us_get_news/cn_get_news（WS4 #1，#6 实现轮）

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-30-market-news-tools.md
+++ b/.agents/notes/implemented/feature/2026-08-30-market-news-tools.md
@@ -1,0 +1,31 @@
+# Agent Note: us/cn 市场新闻工具（WS4 #1）——kit 薄工具 + 补 dsh-tools peer
+
+Status: implemented
+
+## Problem
+
+WS4 #1（docs/analysis-roadmap.md，[#6](https://github.com/zhu1090093659/dsh-trading/issues/6) 子工作流）要按 crypto 新闻模式
+（[#8](../../../../spikes/impl-crypto-news/EVIDENCE.md) 的 `crypto_get_news` 薄工具）复制到 us/cn/hk。前置 spike
+（[PR #10](../../../../spikes/impl-uscnhk-news/EVIDENCE.md)）实测：us 有两源（Yahoo news API + Google News RSS）、cn 有东财快讯（均 A 级），
+hk 无干净公共源。遗留一个复制期结构性坑：kit-us/kit-cn 的 SDK peer 缺 `@deepseek-ai/dsh-tools`。
+
+## Decision
+
+- **us_get_news**（kit-us）：主源 **Yahoo Finance news API**（`/v1/finance/search`，news[] 带 publisher 直链/providerPublishTime）+ 媒体面 **Google News RSS**（`<source>` 为原始媒体名，link 为 Google 跳转——溯源用 source，跳转属已知局限）。`source` 用真实 publisher（铁律 #5 溯源正确）。
+- **cn_get_news**（kit-cn）：主源 **东财快讯**（`getFastNewsList?fastColumn=102`）；`summary` 是正文，**工具只引 title/showTime/链接**（铁律 #5 不再分发）；url 由 `code` 构造 `finance.eastmoney.com/a/<code>.html`（实测 200）；showTime 按东八区无时区后缀 `YYYY-MM-DD HH:MM:SS` 解析为 ISO。
+- **hk_get_news 本轮不实现**：无干净公共源（东财港股列混 A 股不纯、AAStocks 302+JS、HKEX JS/CSRF）——诚实的阻塞项，与 CryptoPanic 同类处置，不当伪完成。
+- 均为 **kit 内薄工具**（非 connector+dataplane——新闻不进行情桥/路由，复用 crypto 判据）；`inject = ['skills','tools']` + duplicate-safe register。
+- **复制期结构性修复（replication.md §1 坑实锤）**：kit-us/kit-cn 的 peerDependencies **漏 `@deepseek-ai/dsh-tools`** → 加入 `defineTool` 后 tsdown 找不到 peer → **内联整个 deepseek-harness vendor 树**（构建 45 文件/419KB，与 kit-crypto 的 3 文件对比鲜明）→ profile 内 import 必崩。已补 `"@deepseek-ai/dsh-tools": ">=0.1.2-alpha.1"`，重建回 3 文件。**replication.md §1 第 1 条的实证反例，后续复制检查点须含「kit 引入新 SDK 面时同步补 peer」**。
+
+## Alternatives considered
+
+- **hk 用东财港股列降级实现**：落选——快讯是统一 CN 金融流、非干净按市场分离，卖「港股新闻」会误导模型与用户；作为阻塞项如实标注比降级掺水更符合定性分析工具的中立性。
+- **us/cn 抽共享 `@dsh-trading/news-core` 包避免聚合逻辑三份**：落选——roadmap 把新闻定为 kit 薄工具（preset 平面、无 GUI 消费），且三源差异大，聚合逻辑重叠低；共享包会引入新包 + replication 建包清单 + profile overrides 同步等成本，铁律 #4（不过早抽象）暂不做。
+- **cn symbol 过滤建中文名映射（600519→贵州茅台）**：落选——隐式维护名称表易漂移；先用东财快讯自带的 `stockList` 关联代码匹配（标题含公司名时按代码命中），中文名限定为已知局限。
+
+## Consequences
+
+- `us_get_news` / `cn_get_news` 无 key 全程可用；us/cn 单测全绿（us 6 / cn 4），tsdown 构建 3 文件（vendor 未内联）。
+- symbol 过滤已知局限：us 媒体多用全名（"Apple"）非 ticker（"AAPL"）→ 标题子串不命中；cn 标题用中文名（贵州茅台）非代码（600519）→ 靠 stockList 代码命中（快讯自带）。均写入工具 description 明示。
+- hk 新闻留待有干净公共源（或按「需 JS/合规抓取前提」裁决）时与 WS4 其余子工作流同批推进；`#6` 保持开放作跟踪伞。
+- 全量 `pnpm -r build`/`-r test` 由 PR CI 承接；本地已对 kit-crypto（16）、kit-us（6）、kit-cn（4）验证。

--- a/packages/kit-cn/package.json
+++ b/packages/kit-cn/package.json
@@ -23,6 +23,7 @@
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.0",
     "@deepseek-ai/dsh-skill": ">=0.1.2-alpha.1",
+    "@deepseek-ai/dsh-tools": ">=0.1.2-alpha.1",
     "@deepseek-ai/schemastery": ">=3.18.0"
   },
   "devDependencies": {

--- a/packages/kit-cn/src/index.ts
+++ b/packages/kit-cn/src/index.ts
@@ -21,6 +21,8 @@ import {
   type SkillDefinition,
   type SkillProvider,
 } from '@deepseek-ai/dsh-skill'
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import { aggregateNews, type AggregateNewsOptions } from './news.js'
 
 // ── skill provider ────────────────────────────────────────────────────────────
 
@@ -74,7 +76,7 @@ export const Config: Schema<Config> = Schema.object({
 })
 
 /** 需要宿主提供的 Cordis 服务。 */
-export const inject = ['skills']
+export const inject = ['skills', 'tools']
 
 /**
  * Cordis 插件名 = preset 行 id（TEMPLATES §8）：`dsh-trading-cn-*` 市场命名空间，
@@ -86,4 +88,83 @@ export const name = 'dsh-trading-cn-kit'
 
 export function apply(ctx: Context, _config: Config): void {
   ctx.skills.registerProvider(() => provider)
+
+  // WS4 #1（#6）：cn_get_news——kit 内薄工具，东财快讯公共源（spike 推荐：A 级，单端点无鉴权）。
+  // 缺省无 key 全程可用；每源独立容错，输出带来源名 + 时间 + 链接（铁律 #5，不引正文）。
+  const newsTool = createGetNewsTool()
+  const tools = ctx.tools as unknown as {
+    register(definition: { name: string }): unknown
+    get(name: string): { name: string } | undefined
+  }
+  if (tools.get(newsTool.name) !== undefined) {
+    ctx.logger('dsh-trading-cn-kit').info(
+      '[dsh-trading-cn-kit] tool %s already registered by another provider — skipped (mutual exclusion)',
+      newsTool.name,
+    )
+    return
+  }
+  tools.register(newsTool)
+}
+
+/* ── cn_get_news：A 股新闻工具（WS4 #1，#6） ─────────────────────────────────── */
+
+const DEFAULT_NEWS_WINDOW_HOURS = 24
+const DEFAULT_NEWS_LIMIT = 20
+
+function renderNewsItem(item: { source: string; title: string; url: string; publishedAt: string }): string {
+  return `[${item.source}] ${item.publishedAt}  ${item.title}\n  ${item.url}`
+}
+
+export function createGetNewsTool() {
+  const description =
+    'Get recent China A-share market news from the public no-key Eastmoney fast-news feed (7x24). '
+    + 'Each item carries source name (东方财富), publish time and a link for traceability. '
+    + 'Optionally filter by symbol (best-effort match against item titles; titles usually use company names rather than codes) and by a time window. '
+    + 'Fetches metadata only (title/time/link), never redistributes article bodies. '
+    + 'No credentials required.'
+  return defineTool({
+    name: 'cn_get_news',
+    description,
+    parameters: {
+      symbol: {
+        type: 'string',
+        description: 'Optional symbol to filter by, market-canonical vocabulary, e.g. 600519 or 600519.SH. Best-effort matched against item titles (Chinese titles use company names, so this is loose).',
+      },
+      windowHours: {
+        type: 'number',
+        description: `Only keep items published within the last N hours (1-168, default ${DEFAULT_NEWS_WINDOW_HOURS}).`,
+        default: DEFAULT_NEWS_WINDOW_HOURS,
+      },
+      limit: {
+        type: 'number',
+        description: `Max items to return (1-50, default ${DEFAULT_NEWS_LIMIT}).`,
+        default: DEFAULT_NEWS_LIMIT,
+      },
+    },
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    async execute(raw) {
+      const args = (raw ?? {}) as { symbol?: unknown; windowHours?: unknown; limit?: unknown }
+      const options: AggregateNewsOptions = {
+        symbol: typeof args.symbol === 'string' ? args.symbol : undefined,
+        windowHours: typeof args.windowHours === 'number' ? args.windowHours : undefined,
+        limit: typeof args.limit === 'number' ? args.limit : undefined,
+      }
+      const { items, unavailable } = await aggregateNews(options)
+      if (items.length === 0 && unavailable.length === 0) {
+        return 'cn_get_news: no news items found within the requested window.'
+      }
+      const symbolNote = options.symbol ? ` symbol=${options.symbol.trim()}` : ''
+      const lines = [
+        `cn_get_news — ${items.length} item(s)${symbolNote}, window=${options.windowHours ?? DEFAULT_NEWS_WINDOW_HOURS}h (newest-first):`,
+        ...items.map(renderNewsItem),
+      ]
+      if (unavailable.length > 0) {
+        lines.push('  (source(s) unavailable this call: ' + unavailable.join('; ') + ')')
+      }
+      return lines.join('\n')
+    },
+  })
 }

--- a/packages/kit-cn/src/news.ts
+++ b/packages/kit-cn/src/news.ts
@@ -49,7 +49,8 @@ interface EastmoneyItem {
   title?: string
   showTime?: string
   code?: string | number
-  stockList?: Array<{ code?: string }>
+  /** 东财快讯关联标的：字符串数组 `<marketId>.<code>`（如 '1.600519'=SH、'116.02493'=HK、'105.AMZN'=US）。 */
+  stockList?: string[]
 }
 
 /** 东财 showTime（YYYY-MM-DD HH:MM:SS，东八区无时区后缀）→ ISO。 */
@@ -62,6 +63,8 @@ async function fetchEastmoney(fetchImpl: typeof globalThis.fetch, limit: number)
   const url = new URL(EASTMONEY_URL)
   url.searchParams.set('client', 'web')
   url.searchParams.set('biz', 'web_724')
+  url.searchParams.set('sortEnd', '')
+  url.searchParams.set('req_trace', '1')
   url.searchParams.set('fastColumn', '102')
   url.searchParams.set('pageSize', String(Math.max(limit, 20)))
   const response = await fetchImpl(url, { headers: { accept: 'application/json', 'user-agent': UA } })
@@ -77,8 +80,9 @@ async function fetchEastmoney(fetchImpl: typeof globalThis.fetch, limit: number)
     if (!it.title || it.code === undefined) continue
     const ts = typeof it.showTime === 'string' ? parseCnShowTime(it.showTime) : NaN
     if (!Number.isFinite(ts)) continue
+    // relatedCodes 保留完整 `<marketId>.<code>`（如 '1.600519'/'116.00700'），匹配时取 code 段。
     const relatedCodes = Array.isArray(it.stockList)
-      ? it.stockList.filter((s) => typeof s?.code === 'string').map((s) => s.code as string)
+      ? it.stockList.filter((s) => typeof s === 'string' && s.includes('.'))
       : undefined
     items.push({
       source: 'eastmoney',
@@ -107,7 +111,8 @@ function matchesSymbol(item: NewsItem, rawSymbol?: string): boolean {
   const tokens = [needle.toUpperCase(), base.toUpperCase()]
   if (tokens.some((t) => t && title.includes(t))) return true
   if (item.relatedCodes) {
-    const codes = item.relatedCodes.map((c) => c.toUpperCase())
+    // 东财 code = `<marketId>.<code>`；按 . 后 code 段匹配（'1.600519' → '600519'）。
+    const codes = item.relatedCodes.map((c) => c.split('.').slice(-1)[0].toUpperCase())
     return tokens.some((t) => t && codes.includes(t))
   }
   return false

--- a/packages/kit-cn/src/news.ts
+++ b/packages/kit-cn/src/news.ts
@@ -1,0 +1,145 @@
+/**
+ * cn_get_news 取数层（WS4 #1：#6 子工作流，spike/s impl-uscnhk-news EVIDENCE 推荐）。
+ *
+ * cn 主源 = 东方财富快讯 API（本出口 200 无 key；新浪/财联社不可用，spike C/D 级）：
+ *   GET np-listapi.eastmoney.com/comm/web/getFastNewsList?fastColumn=102
+ * 字段：fastNewsList[] = { title, showTime(YYYY-MM-DD HH:MM:SS, 东八区), code, summary(正文) }；
+ * url 由 code 构造 finance.eastmoney.com/a/<code>.html（实测可达）。
+ * 铁律 #5：summary 是正文，**只引 title/showTime/链接**（元数据），不取 summary 再分发。
+ * 每源失败 fail-soft（unavailable 注明）；时间窗/标的过滤 + 排序截尾；defineTool 在 index.ts。
+ */
+export type NewsSource = 'eastmoney'
+
+export interface NewsItem {
+  /** 来源名（铁律 #5 的来源标注）。 */
+  source: string
+  title: string
+  url: string
+  /** ISO 8601 发布时间（东八区换算）。 */
+  publishedAt: string
+  /** 关联股票代码（东财快讯 stockList，供 symbol 过滤）。 */
+  relatedCodes?: string[]
+}
+
+export interface AggregateNewsOptions {
+  /** 标的（市场规范词汇，如 600519 / 600519.SH）；缺省 = 不过滤。 */
+  symbol?: string
+  /** 时间窗（小时）：只保留 now - windowHours 内的条目；缺省 24。 */
+  windowHours?: number
+  /** 输出条数上限；缺省 20。 */
+  limit?: number
+  /** 依赖注入的 fetch（测试用 mock；缺省 globalThis.fetch）。 */
+  fetch?: typeof globalThis.fetch
+  /** 注入当前时间戳（ms，测试用）；缺省 Date.now()。 */
+  now?: number
+}
+
+export interface AggregateNewsResult {
+  items: NewsItem[]
+  unavailable: string[]
+}
+
+const EASTMONEY_URL = 'https://np-listapi.eastmoney.com/comm/web/getFastNewsList'
+const DEFAULT_WINDOW_HOURS = 24
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 50
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (dsh-trading/cn_get_news)'
+
+interface EastmoneyItem {
+  title?: string
+  showTime?: string
+  code?: string | number
+  stockList?: Array<{ code?: string }>
+}
+
+/** 东财 showTime（YYYY-MM-DD HH:MM:SS，东八区无时区后缀）→ ISO。 */
+export function parseCnShowTime(showTime: string): number {
+  const t = Date.parse(showTime.trim().replace(' ', 'T') + '+08:00')
+  return Number.isFinite(t) ? t : NaN
+}
+
+async function fetchEastmoney(fetchImpl: typeof globalThis.fetch, limit: number): Promise<NewsItem[]> {
+  const url = new URL(EASTMONEY_URL)
+  url.searchParams.set('client', 'web')
+  url.searchParams.set('biz', 'web_724')
+  url.searchParams.set('fastColumn', '102')
+  url.searchParams.set('pageSize', String(Math.max(limit, 20)))
+  const response = await fetchImpl(url, { headers: { accept: 'application/json', 'user-agent': UA } })
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`eastmoney: HTTP ${response.status}${body ? ` — ${body.slice(0, 160)}` : ''}`)
+  }
+  const parsed: unknown = JSON.parse(await response.text())
+  const list = (parsed as { data?: { fastNewsList?: EastmoneyItem[] } }).data?.fastNewsList
+  if (!Array.isArray(list)) throw new Error('eastmoney: unexpected payload (expected data.fastNewsList[])')
+  const items: NewsItem[] = []
+  for (const it of list) {
+    if (!it.title || it.code === undefined) continue
+    const ts = typeof it.showTime === 'string' ? parseCnShowTime(it.showTime) : NaN
+    if (!Number.isFinite(ts)) continue
+    const relatedCodes = Array.isArray(it.stockList)
+      ? it.stockList.filter((s) => typeof s?.code === 'string').map((s) => s.code as string)
+      : undefined
+    items.push({
+      source: 'eastmoney',
+      title: it.title,
+      url: `https://finance.eastmoney.com/a/${encodeURIComponent(String(it.code))}.html`,
+      publishedAt: new Date(ts).toISOString(),
+      ...(relatedCodes && relatedCodes.length > 0 ? { relatedCodes } : {}),
+    })
+  }
+  return items
+}
+
+function inWindow(publishedAt: string, nowMs: number, windowMs: number): boolean {
+  const ts = Date.parse(publishedAt)
+  if (!Number.isFinite(ts)) return false
+  return ts >= nowMs - windowMs && ts <= nowMs + 60_000
+}
+
+function matchesSymbol(item: NewsItem, rawSymbol?: string): boolean {
+  const needle = rawSymbol?.trim()
+  if (!needle) return true
+  const title = item.title.toUpperCase()
+  const base = needle.replace(/\.(SH|SZ|BJ)$/i, '')
+  // cn 标题常用公司中文名（贵州茅台）非代码（600519）——先按代码匹配标题或关联股票代码（stockList），
+  // 中文名匹配是已知局限（不隐式建名称映射）。
+  const tokens = [needle.toUpperCase(), base.toUpperCase()]
+  if (tokens.some((t) => t && title.includes(t))) return true
+  if (item.relatedCodes) {
+    const codes = item.relatedCodes.map((c) => c.toUpperCase())
+    return tokens.some((t) => t && codes.includes(t))
+  }
+  return false
+}
+
+function clampNumber(value: number | undefined, fallback: number, min: number, max: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.min(Math.max(Math.trunc(value), min), max)
+}
+
+export async function aggregateNews(options: AggregateNewsOptions = {}): Promise<AggregateNewsResult> {
+  const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis)
+  const now = options.now ?? Date.now()
+  const windowHours = clampNumber(options.windowHours, DEFAULT_WINDOW_HOURS, 1, 24 * 7)
+  const windowMs = windowHours * 3_600_000
+  const limit = clampNumber(options.limit, DEFAULT_LIMIT, 1, MAX_LIMIT)
+
+  const results = await Promise.allSettled([fetchEastmoney(fetchImpl, limit)])
+
+  const items: NewsItem[] = []
+  const unavailable: string[] = []
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      for (const item of result.value) {
+        if (!inWindow(item.publishedAt, now, windowMs)) continue
+        if (!matchesSymbol(item, options.symbol)) continue
+        items.push(item)
+      }
+    } else {
+      unavailable.push(result.reason instanceof Error ? result.reason.message : String(result.reason))
+    }
+  }
+  items.sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt))
+  return { items: items.slice(0, limit), unavailable }
+}

--- a/packages/kit-cn/test/news.test.ts
+++ b/packages/kit-cn/test/news.test.ts
@@ -16,7 +16,7 @@ const failResp = (status: number, body = 'boom'): Resp => ({ ok: false, status, 
 const eastmoneyJson = {
   data: {
     fastNewsList: [
-      { title: '贵州茅台发布半年度业绩', showTime: '2026-08-30 19:00:00', code: '202608300001', summary: '【正文】...', stockList: [{ code: '600519' }] },
+      { title: '贵州茅台发布半年度业绩', showTime: '2026-08-30 19:00:00', code: '202608300001', summary: '【正文】...', stockList: ['1.600519'] },
       { title: '沪指收盘涨0.5%', showTime: '2026-08-29 15:00:00', code: '202608290002', summary: '【正文】...' },
     ],
   },
@@ -46,6 +46,17 @@ describe('aggregateNews（东财单源聚合 + 过滤）', () => {
     expect(first?.publishedAt).toBe(new Date(Date.parse('2026-08-30T19:00:00+08:00')).toISOString())
     // 29 日 15:00（东八区）相对 now(2026-08-30T20:00Z=08-31 04:00 北京) 超窗被滤
     expect(items.some((i) => i.title.includes('沪指'))).toBe(false)
+  })
+
+  it('东财请求必带 sortEnd 与 req_trace=1（缺一该端点返 data:null 致整源失败）', async () => {
+    let url = ''
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      url = String(input)
+      return jsonResp(eastmoneyJson)
+    }) as unknown as typeof globalThis.fetch
+    await aggregateNews({ fetch: fetchImpl, now: NOW })
+    expect(url).toContain('sortEnd=')
+    expect(url).toContain('req_trace=1')
   })
 
   it('symbol 过滤：600519 命中（含 .SH 归一化）；单源失败 fail-soft', async () => {

--- a/packages/kit-cn/test/news.test.ts
+++ b/packages/kit-cn/test/news.test.ts
@@ -1,0 +1,74 @@
+/**
+ * cn_get_news 取数层/工具单测（WS4 #1：#6；spike EVIDENCE 推荐东财快讯）。
+ * mock fetch，不触真实网络。覆盖：东财解析（showTime 东八区 → ISO、url 由 code 构造）、
+ * 聚合/过滤/容错、工具壳渲染。
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { aggregateNews, parseCnShowTime } from '../src/news.ts'
+import { createGetNewsTool } from '../src/index.ts'
+
+const NOW = Date.parse('2026-08-30T20:00:00Z')
+
+type Resp = { ok: boolean; status: number; text: () => Promise<string> }
+const jsonResp = (obj: unknown): Resp => ({ ok: true, status: 200, text: async () => JSON.stringify(obj) })
+const failResp = (status: number, body = 'boom'): Resp => ({ ok: false, status, text: async () => body })
+
+const eastmoneyJson = {
+  data: {
+    fastNewsList: [
+      { title: '贵州茅台发布半年度业绩', showTime: '2026-08-30 19:00:00', code: '202608300001', summary: '【正文】...', stockList: [{ code: '600519' }] },
+      { title: '沪指收盘涨0.5%', showTime: '2026-08-29 15:00:00', code: '202608290002', summary: '【正文】...' },
+    ],
+  },
+}
+
+function mockFetch(resp: Resp) {
+  return vi.fn(async () => resp) as unknown as typeof globalThis.fetch
+}
+
+afterEach(() => { vi.unstubAllGlobals() })
+
+describe('parseCnShowTime（东财时间 → 东八区 ISO 毫秒）', () => {
+  it('解析东八区无时区后缀的 showTime', () => {
+    const ts = parseCnShowTime('2026-08-30 19:00:00')
+    expect(ts).toBe(Date.parse('2026-08-30T19:00:00+08:00'))
+    expect(Number.isNaN(parseCnShowTime('bad'))).toBe(true)
+  })
+})
+
+describe('aggregateNews（东财单源聚合 + 过滤）', () => {
+  it('解析列表：url 由 code 构造、source=eastmoney、时间过滤 24h 窗、不引 summary', async () => {
+    const { items, unavailable } = await aggregateNews({ fetch: mockFetch(jsonResp(eastmoneyJson)), now: NOW })
+    expect(unavailable).toEqual([])
+    const first = items.find((i) => i.title.includes('贵州茅台'))
+    expect(first?.source).toBe('eastmoney')
+    expect(first?.url).toBe('https://finance.eastmoney.com/a/202608300001.html')
+    expect(first?.publishedAt).toBe(new Date(Date.parse('2026-08-30T19:00:00+08:00')).toISOString())
+    // 29 日 15:00（东八区）相对 now(2026-08-30T20:00Z=08-31 04:00 北京) 超窗被滤
+    expect(items.some((i) => i.title.includes('沪指'))).toBe(false)
+  })
+
+  it('symbol 过滤：600519 命中（含 .SH 归一化）；单源失败 fail-soft', async () => {
+    const fetchImpl = mockFetch(jsonResp(eastmoneyJson))
+    const withSymbol = await aggregateNews({ fetch: fetchImpl, now: NOW, symbol: '600519.SH' })
+    expect(withSymbol.items.some((i) => i.title.includes('贵州茅台'))).toBe(true)
+    const failFetch = mockFetch(failResp(500))
+    const failed = await aggregateNews({ fetch: failFetch, now: NOW })
+    expect(failed.unavailable.some((u) => u.includes('eastmoney'))).toBe(true)
+    expect(failed.items).toHaveLength(0)
+  })
+})
+
+describe('createGetNewsTool（工具壳）', () => {
+  it('execute 渲染：含来源、时间、链接与 unavailable 注记', async () => {
+    const base = Date.now() - 1_800_000
+    const near = { data: { fastNewsList: [{ title: '贵州茅台涨停', showTime: new Date(base).toISOString().slice(0, 19).replace('T', ' '), code: '202608300001', summary: 'x' }] } }
+    vi.stubGlobal('fetch', mockFetch(jsonResp(near)))
+    const tool = createGetNewsTool()
+    expect(tool.name).toBe('cn_get_news')
+    const text = await tool.execute({ windowHours: 24, limit: 10 }) as string
+    expect(text).toContain('cn_get_news — ')
+    expect(text).toContain('[eastmoney]')
+    expect(text).toContain('https://finance.eastmoney.com/a/202608300001.html')
+  })
+})

--- a/packages/kit-us/package.json
+++ b/packages/kit-us/package.json
@@ -23,6 +23,7 @@
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.0",
     "@deepseek-ai/dsh-skill": ">=0.1.2-alpha.1",
+    "@deepseek-ai/dsh-tools": ">=0.1.2-alpha.1",
     "@deepseek-ai/schemastery": ">=3.18.0"
   },
   "devDependencies": {

--- a/packages/kit-us/src/index.ts
+++ b/packages/kit-us/src/index.ts
@@ -26,6 +26,8 @@ import {
   type SkillDefinition,
   type SkillProvider,
 } from '@deepseek-ai/dsh-skill'
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import { aggregateNews, type AggregateNewsOptions } from './news.js'
 
 // ── skill provider（host 面 skill 全局可见即可，本切片不改 skill 作用域） ─────────
 
@@ -79,7 +81,7 @@ export const Config: Schema<Config> = Schema.object({
 })
 
 /** 需要宿主提供的 Cordis 服务。 */
-export const inject = ['skills']
+export const inject = ['skills', 'tools']
 
 /**
  * Cordis 插件名 = preset 行 id（TEMPLATES §8）：`dsh-trading-us-*` 市场命名空间，
@@ -91,4 +93,82 @@ export const name = 'dsh-trading-us-kit'
 
 export function apply(ctx: Context, _config: Config): void {
   ctx.skills.registerProvider(() => provider)
+
+  // WS4 #1（#6）：us_get_news——kit 内薄工具，直连公共源（spike 推荐：Yahoo + Google RSS 均单端点无鉴权，
+  // 无 connector 契约要素）。缺省无 key 全程可用；每源独立容错，输出带来源名 + 时间 + 链接（铁律 #5）。
+  const newsTool = createGetNewsTool()
+  const tools = ctx.tools as unknown as {
+    register(definition: { name: string }): unknown
+    get(name: string): { name: string } | undefined
+  }
+  if (tools.get(newsTool.name) !== undefined) {
+    ctx.logger('dsh-trading-us-kit').info(
+      '[dsh-trading-us-kit] tool %s already registered by another provider — skipped (mutual exclusion)',
+      newsTool.name,
+    )
+    return
+  }
+  tools.register(newsTool)
+}
+
+/* ── us_get_news：美股新闻工具（WS4 #1，#6） ─────────────────────────────────── */
+
+const DEFAULT_NEWS_WINDOW_HOURS = 24
+const DEFAULT_NEWS_LIMIT = 20
+
+function renderNewsItem(item: { source: string; title: string; url: string; publishedAt: string }): string {
+  return `[${item.source}] ${item.publishedAt}  ${item.title}\n  ${item.url}`
+}
+
+export function createGetNewsTool() {
+  const description =
+    'Get recent US stock market news from public no-key sources (Yahoo Finance news + Google News RSS). '
+    + 'Aggregates and sorts newest-first; each item carries source name (publisher), publish time and a link for traceability. '
+    + 'Optionally filter by symbol (matched against item titles; note media headlines often use company names like "Apple" rather than tickers) and by a time window. '
+    + 'Source failures are tolerated and reported instead of failing the whole call. No credentials required. Distinguish announcements/regulatory from opinion (media) when citing.'
+  return defineTool({
+    name: 'us_get_news',
+    description,
+    parameters: {
+      symbol: {
+        type: 'string',
+        description: 'Optional symbol to filter by, market-canonical vocabulary, e.g. AAPL or TSLA. Used as the search query and matched against item titles.',
+      },
+      windowHours: {
+        type: 'number',
+        description: `Only keep items published within the last N hours (1-168, default ${DEFAULT_NEWS_WINDOW_HOURS}).`,
+        default: DEFAULT_NEWS_WINDOW_HOURS,
+      },
+      limit: {
+        type: 'number',
+        description: `Max items to return (1-50, default ${DEFAULT_NEWS_LIMIT}).`,
+        default: DEFAULT_NEWS_LIMIT,
+      },
+    },
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    async execute(raw) {
+      const args = (raw ?? {}) as { symbol?: unknown; windowHours?: unknown; limit?: unknown }
+      const options: AggregateNewsOptions = {
+        symbol: typeof args.symbol === 'string' ? args.symbol : undefined,
+        windowHours: typeof args.windowHours === 'number' ? args.windowHours : undefined,
+        limit: typeof args.limit === 'number' ? args.limit : undefined,
+      }
+      const { items, unavailable } = await aggregateNews(options)
+      if (items.length === 0 && unavailable.length === 0) {
+        return 'us_get_news: no news items found within the requested window.'
+      }
+      const symbolNote = options.symbol ? ` symbol=${options.symbol.trim().toUpperCase()}` : ''
+      const lines = [
+        `us_get_news — ${items.length} item(s)${symbolNote}, window=${options.windowHours ?? DEFAULT_NEWS_WINDOW_HOURS}h (newest-first):`,
+        ...items.map(renderNewsItem),
+      ]
+      if (unavailable.length > 0) {
+        lines.push('  (source(s) unavailable this call: ' + unavailable.join('; ') + ')')
+      }
+      return lines.join('\n')
+    },
+  })
 }

--- a/packages/kit-us/src/news.ts
+++ b/packages/kit-us/src/news.ts
@@ -1,0 +1,189 @@
+/**
+ * us_get_news 取数层（WS4 #1：#6 子工作流，spike/s impl-uscnhk-news EVIDENCE 推荐）。
+ *
+ * 两源均为单端点、无鉴权、无状态公共 GET（本出口实测）：
+ *   - Yahoo Finance news API（v8 家族，与既有 connector-yahoo 同族）——JSON，news[] 带 publisher/link/publishTime
+ *   - Google News RSS（news.google.com/rss/search）——RSS 2.0，<source> 为原始媒体名；link 为 Google 跳转链接
+ * 本模块只做取数 + 归一化为 NewsItem[]；时间窗/币种过滤 + 排序截尾；defineTool 装配在 index.ts。
+ * 铁律 #5：输出只带元数据（来源名/标题/链接/发布时间），不取正文，不缓存，不再分发。
+ * 每源独立容错：单源失败不炸整体，失败源在 `unavailable` 中注明，fail-soft。
+ */
+export type NewsSource = 'yahoo' | 'googlenews'
+
+export interface NewsItem {
+  /** 来源名（铁律 #5 的来源标注）。 */
+  source: string
+  title: string
+  url: string
+  /** ISO 8601 发布时间。 */
+  publishedAt: string
+}
+
+export interface AggregateNewsOptions {
+  /** 标的（市场规范词汇，如 AAPL）；缺省 = 通用市场主题。 */
+  symbol?: string
+  /** 时间窗（小时）：只保留 now - windowHours 内的条目；缺省 24。 */
+  windowHours?: number
+  /** 输出条数上限；缺省 20。 */
+  limit?: number
+  /** 依赖注入的 fetch（测试用 mock；缺省 globalThis.fetch）。 */
+  fetch?: typeof globalThis.fetch
+  /** 注入当前时间戳（ms，测试用）；缺省 Date.now()。 */
+  now?: number
+}
+
+export interface AggregateNewsResult {
+  items: NewsItem[]
+  /** 取数失败的源：`<匿名>`（如 'yahoo: HTTP 500 — ...'），工具输出需注明缺席。 */
+  unavailable: string[]
+}
+
+const YAHOO_SEARCH_URL = 'https://query1.finance.yahoo.com/v1/finance/search'
+const GOOGLE_NEWS_RSS_URL = 'https://news.google.com/rss/search'
+
+const DEFAULT_WINDOW_HOURS = 24
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 50
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (dsh-trading/us_get_news)'
+/** 无 symbol 时的通用市场主题（避免空 query）。 */
+const DEFAULT_QUERY_TOPIC = 'US stock market'
+
+async function fetchText(url: string, fetchImpl: typeof globalThis.fetch, name: string): Promise<string> {
+  const response = await fetchImpl(url, { headers: { accept: 'application/json, text/xml, */*', 'user-agent': UA } })
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(`${name}: HTTP ${response.status}${body ? ` — ${body.slice(0, 160)}` : ''}`)
+  }
+  return response.text()
+}
+
+/* ── Yahoo Finance news API（JSON；news[] 字段齐） ─────────────────────────── */
+
+interface YahooNewsItem {
+  title?: string
+  link?: string
+  publisher?: string
+  providerPublishTime?: number
+}
+
+async function fetchYahooNews(fetchImpl: typeof globalThis.fetch, topic: string, limit: number): Promise<NewsItem[]> {
+  const url = new URL(YAHOO_SEARCH_URL)
+  url.searchParams.set('q', topic)
+  url.searchParams.set('newsCount', String(limit))
+  url.searchParams.set('quotesCount', '0')
+  url.searchParams.set('enableFuzzyQuery', 'false')
+  const text = await fetchText(url.toString(), fetchImpl, 'yahoo')
+  const parsed: unknown = JSON.parse(text)
+  const news = (parsed as { news?: YahooNewsItem[] }).news
+  if (!Array.isArray(news)) throw new Error('yahoo: unexpected payload (expected news[])')
+  const items: NewsItem[] = []
+  for (const n of news) {
+    if (!n.title || !n.link) continue
+    const ts = typeof n.providerPublishTime === 'number' ? n.providerPublishTime * 1000 : NaN
+    if (!Number.isFinite(ts)) continue
+    items.push({
+      source: n.publisher || 'yahoo',
+      title: n.title,
+      url: n.link,
+      publishedAt: new Date(ts).toISOString(),
+    })
+  }
+  return items
+}
+
+/* ── Google News RSS（RSS 2.0；<source> 为原始媒体名） ─────────────────────── */
+
+function decodeXmlText(raw: string): string {
+  return raw.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, (_, m) => m)
+    .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&apos;/g, "'")
+    .replace(/&#([0-9]+);/g, (_, n) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+    .trim()
+}
+
+function extractTag(block: string, tag: string): string {
+  const re = new RegExp(`<${tag}[\\s>][\\s\\S]*?<\\/${tag}>`, 'i')
+  const match = block.match(re)
+  if (!match) return ''
+  return decodeXmlText(match[0].replace(new RegExp(`<\\/?${tag}[^>]*>`, 'gi'), ''))
+}
+
+/** 解析 Google News RSS（title/link/pubDate/source；link 为 Google 跳转，溯源用 source）。 */
+export function parseGoogleNewsRss(xml: string): NewsItem[] {
+  const items: NewsItem[] = []
+  const blocks = xml.match(/<item[\s>][\s\S]*?<\/item>/gi) ?? []
+  for (const block of blocks) {
+    const title = extractTag(block, 'title')
+    const link = extractTag(block, 'link')
+    if (!title || !link) continue
+    const pubDate = extractTag(block, 'pubDate')
+    const ts = Date.parse(pubDate)
+    if (!Number.isFinite(ts)) continue
+    const source = extractTag(block, 'source') || 'googlenews'
+    items.push({ source, title, url: link, publishedAt: new Date(ts).toISOString() })
+  }
+  return items
+}
+
+async function fetchGooglenews(fetchImpl: typeof globalThis.fetch, topic: string, limit: number): Promise<NewsItem[]> {
+  const url = new URL(GOOGLE_NEWS_RSS_URL)
+  url.searchParams.set('q', topic)
+  url.searchParams.set('hl', 'en-US')
+  url.searchParams.set('gl', 'US')
+  url.searchParams.set('ceid', 'US:en')
+  const text = await fetchText(url.toString(), fetchImpl, 'googlenews')
+  return parseGoogleNewsRss(text).slice(0, limit)
+}
+
+/* ── 聚合：并发取两源 → 时间窗/标的过滤 → 按时间倒序 → 截尾 ──────────────────── */
+
+function inWindow(publishedAt: string, nowMs: number, windowMs: number): boolean {
+  const ts = Date.parse(publishedAt)
+  if (!Number.isFinite(ts)) return false
+  return ts >= nowMs - windowMs && ts <= nowMs + 60_000 // 允许 1 分钟时钟误差
+}
+
+function matchesSymbol(item: NewsItem, rawSymbol?: string): boolean {
+  if (!rawSymbol) return true
+  const needle = rawSymbol.trim().toUpperCase()
+  if (!needle) return true
+  const title = item.title.toUpperCase()
+  // 已知局限：媒体标题常用全名（"Apple"）而非 ticker（"AAPL"），此处仅按 ticker/base 子串匹配。
+  return title.includes(needle)
+}
+
+function clampNumber(value: number | undefined, fallback: number, min: number, max: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback
+  return Math.min(Math.max(Math.trunc(value), min), max)
+}
+
+export async function aggregateNews(options: AggregateNewsOptions = {}): Promise<AggregateNewsResult> {
+  const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis)
+  const now = options.now ?? Date.now()
+  const windowHours = clampNumber(options.windowHours, DEFAULT_WINDOW_HOURS, 1, 24 * 7)
+  const windowMs = windowHours * 3_600_000
+  const limit = clampNumber(options.limit, DEFAULT_LIMIT, 1, MAX_LIMIT)
+  const topic = (options.symbol?.trim() || DEFAULT_QUERY_TOPIC)
+
+  const results = await Promise.allSettled([
+    fetchYahooNews(fetchImpl, topic, limit),
+    fetchGooglenews(fetchImpl, topic, limit),
+  ])
+
+  const items: NewsItem[] = []
+  const unavailable: string[] = []
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      for (const item of result.value) {
+        if (!inWindow(item.publishedAt, now, windowMs)) continue
+        if (!matchesSymbol(item, options.symbol)) continue
+        items.push(item)
+      }
+    } else {
+      unavailable.push(result.reason instanceof Error ? result.reason.message : String(result.reason))
+    }
+  }
+  items.sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt))
+  return { items: items.slice(0, limit), unavailable }
+}

--- a/packages/kit-us/test/news.test.ts
+++ b/packages/kit-us/test/news.test.ts
@@ -1,0 +1,110 @@
+/**
+ * us_get_news 取数层/工具单测（WS4 #1：#6；spike EVIDENCE 推荐 Yahoo + Google News RSS）。
+ * mock fetch，不触真实网络。覆盖：两源聚合/倒序/截尾、symbol 过滤、时间窗、单源容错、RSS 解析。
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { aggregateNews, parseGoogleNewsRss } from '../src/news.ts'
+import { createGetNewsTool } from '../src/index.ts'
+
+const NOW = Date.parse('2026-08-30T20:00:00Z')
+
+type Resp = { ok: boolean; status: number; text: () => Promise<string> }
+const jsonResp = (obj: unknown): Resp => ({ ok: true, status: 200, text: async () => JSON.stringify(obj) })
+const textResp = (str: string): Resp => ({ ok: true, status: 200, text: async () => str })
+const failResp = (status: number, body = 'boom'): Resp => ({ ok: false, status, text: async () => body })
+
+const yahooJson = {
+  news: [
+    { uuid: '1', title: 'AAPL: Apple beats Q3 earnings estimates', link: 'https://finance.yahoo.com/1', publisher: 'Yahoo Finance', providerPublishTime: NOW / 1000 - 3600 },
+    { uuid: '2', title: 'TSLA shares tumble on delivery miss', link: 'https://finance.yahoo.com/2', publisher: 'Reuters', providerPublishTime: NOW / 1000 - 7200 },
+  ],
+}
+
+const googleRss = `<?xml version="1.0"?><rss version="2.0"><channel>
+  <title>Google News</title>
+  <item><title>Apple stock hits record high &amp; more</title><link>https://news.google.com/rss/articles/a</link><guid>a</guid><pubDate>Sun, 30 Aug 2026 18:00:00 GMT</pubDate><source url="https://example.com">MarketWatch</source></item>
+  <item><title>Amazon retail sales beat estimates</title><link>https://news.google.com/rss/articles/b</link><guid>b</guid><pubDate>Sat, 29 Aug 2026 09:00:00 GMT</pubDate><source>CNBC</source></item>
+</channel></rss>`
+
+function mockFetchByUrl(responses: Record<string, () => Resp>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    const hit = Object.entries(responses).find(([substr]) => url.includes(substr))
+    if (!hit) throw new Error(`unexpected fetch: ${url}`)
+    return hit[1]()
+  }) as unknown as typeof globalThis.fetch
+}
+
+function allSourcesOk() {
+  return mockFetchByUrl({
+    'finance.yahoo.com': () => jsonResp(yahooJson),
+    'news.google.com': () => textResp(googleRss),
+  })
+}
+
+afterEach(() => { vi.unstubAllGlobals() })
+
+describe('aggregateNews（两源聚合 + 过滤）', () => {
+  it('两源合并、按时间倒序、无参数默认过 24h 窗；source = 原始 publisher', async () => {
+    const { items, unavailable } = await aggregateNews({ fetch: allSourcesOk(), now: NOW })
+    expect(unavailable).toEqual([])
+    expect(items.map((i) => i.source).sort()).toEqual(['MarketWatch', 'Reuters', 'Yahoo Finance'])
+    const ts = items.map((i) => Date.parse(i.publishedAt))
+    expect(ts).toEqual([...ts].sort((a, b) => b - a))
+    // google rss 第二条 29 日 09:00（now-35h）超窗被滤
+    expect(items.some((i) => i.title.includes('Amazon'))).toBe(false)
+  })
+
+  it('symbol 过滤：AAPL 命中含 "AAPL" 标题；媒体用全名（Apple）不命中（已知局限）', async () => {
+    const { items } = await aggregateNews({ fetch: allSourcesOk(), now: NOW, symbol: 'AAPL' })
+    const titles = items.map((i) => i.title)
+    expect(titles).toContain('AAPL: Apple beats Q3 earnings estimates')
+    expect(titles.some((t) => t.includes('TSLA'))).toBe(false)
+    expect(titles.some((t) => t.includes('Apple stock hits record high'))).toBe(false) // "Apple..." 不含 AAPL
+  })
+
+  it('windowHours 压缩时间窗 + limit 截尾', async () => {
+    const { items } = await aggregateNews({ fetch: allSourcesOk(), now: NOW, windowHours: 1, limit: 1 })
+    expect(items).toHaveLength(1)
+  })
+
+  it('单源失败不炸整体，unavailable 注明该源', async () => {
+    const fetchImpl = mockFetchByUrl({
+      'finance.yahoo.com': () => failResp(500),
+      'news.google.com': () => textResp(googleRss),
+    })
+    const { items, unavailable } = await aggregateNews({ fetch: fetchImpl, now: NOW })
+    expect(unavailable.some((u) => u.includes('yahoo'))).toBe(true)
+    expect(items.some((i) => i.source === 'MarketWatch')).toBe(true)
+  })
+})
+
+describe('parseGoogleNewsRss（RSS 2.0 解析）', () => {
+  it('解析 title/link/pubDate；source 为原始媒体名；无效 pubDate 跳过', () => {
+    const items = parseGoogleNewsRss(googleRss)
+    expect(items).toHaveLength(2)
+    expect(items[0].source).toBe('MarketWatch')
+    expect(items[0].url).toBe('https://news.google.com/rss/articles/a')
+  })
+})
+
+describe('createGetNewsTool（工具壳）', () => {
+  it('execute 渲染：含来源、时间、链接、symbol 与 unavailable 注记', async () => {
+    const base = Date.now() - 3_600_000
+    const nearYahoo = { news: [{ uuid: '1', title: 'AAPL: Apple beats Q3 earnings estimates', link: 'https://finance.yahoo.com/1', publisher: 'Reuters', providerPublishTime: base / 1000 }] }
+    const nearGoogle = `<rss><channel><item><title>Apple stock record</title><link>https://news.google.com/a</link><guid>a</guid><pubDate>${new Date(base).toUTCString()}</pubDate><source>MarketWatch</source></item></channel></rss>`
+    const fetchImpl = mockFetchByUrl({
+      'finance.yahoo.com': () => jsonResp(nearYahoo),
+      'news.google.com': () => textResp(nearGoogle),
+    })
+    vi.stubGlobal('fetch', fetchImpl)
+    const tool = createGetNewsTool()
+    expect(tool.name).toBe('us_get_news')
+    const text = await tool.execute({ symbol: 'AAPL', windowHours: 24, limit: 10 }) as string
+    expect(text).toContain('us_get_news — ')
+    expect(text).toContain('[Reuters]')
+    expect(text).toContain('https://finance.yahoo.com/1')
+    expect(text).toContain('symbol=AAPL')
+    expect(text).not.toContain('source(s) unavailable')
+  })
+})


### PR DESCRIPTION
Part of #6（WS4 #1「us/cn/hk 新闻源」实现轮——**us/cn 已交付，hk 无干净公共源本轮不实现**；#6 是 backlog 跟踪伞，保持开放）。

## 交付内容

- **`us_get_news`**（kit-us）：主源 **Yahoo Finance news API**（`/v1/finance/search`，news[] 带 publisher 直链/providerPublishTime）+ 媒体面 **Google News RSS**（`<source>` 为原始媒体名、link 为 Google 跳转——已知局限）。`source` 用真实 publisher（铁律 #5 溯源）。
- **`cn_get_news`**（kit-cn）：主源 **东财快讯**（`getFastNewsList?fastColumn=102`）；`summary`=正文**不引**（铁律 #5 只引 title/链接/时间）；url 由 `code` 构造（实测 200）；showTime 按东八区解析；symbol 过滤走快讯自带的 `stockList` 关联代码。
- **`hk_get_news` 本轮不实现**：无干净公共源（spike：东财港股列混 A 股不纯、AAStocks 302+JS、HKEX JS/CSRF）——诚实的阻塞项，与 CryptoPanic 同类，不当伪完成。

## 复制期结构性修复（replication.md §1 坑实锤）

kit-us/kit-cn 的 peerDependencies **漏 `@deepseek-ai/dsh-tools`**：加入 `defineTool` 后 tsdown 找不到 peer → **内联整个 deepseek-harness vendor 树**（构建 45 文件/419KB，对比 kit-crypto 的 3 文件）→ profile 内 import 必崩。已补 peer 并重建回 3 文件。replication.md §1 检查点已据此更新（「kit 引入新 SDK 面时同步补 peer」）。

## 验证

- 单测全绿：kit-crypto 16 / kit-us 6 / kit-cn 4；三 kit tsdown 均 3 文件（vendor 未内联）。
- 实时网络（无 mock）在 spike PR #10 EVIDENCE 中实测 Y 200/Google 200/东财 200。

## 已知局限（写入工具描述）

- symbol 过滤：us 媒体多用全名（"Apple"）非 ticker（"AAPL"）→ 标题子串不命中；cn 标题用中文名（贵州茅台）非代码（600519）→ 靠 stockList 代码命中。

@zhu1090093659 请连同 spike PR #10 一起审；hk 处置（降级 vs 阻塞项）待裁决。