### PR TITLE
feat: hk_get_news 降级实现（东财 116. 港股过滤）+ 修 cn 东财参数坑（#6）

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-30-market-news-tools.md
+++ b/.agents/notes/implemented/feature/2026-08-30-market-news-tools.md
@@ -27,5 +27,9 @@ hk 无干净公共源。遗留一个复制期结构性坑：kit-us/kit-cn 的 SD
 
 - `us_get_news` / `cn_get_news` 无 key 全程可用；us/cn 单测全绿（us 6 / cn 4），tsdown 构建 3 文件（vendor 未内联）。
 - symbol 过滤已知局限：us 媒体多用全名（"Apple"）非 ticker（"AAPL"）→ 标题子串不命中；cn 标题用中文名（贵州茅台）非代码（600519）→ 靠 stockList 代码命中（快讯自带）。均写入工具 description 明示。
-- hk 新闻留待有干净公共源（或按「需 JS/合规抓取前提」裁决）时与 WS4 其余子工作流同批推进；`#6` 保持开放作跟踪伞。
-- 全量 `pnpm -r build`/`-r test` 由 PR CI 承接；本地已对 kit-crypto（16）、kit-us（6）、kit-cn（4）验证。
+- **hk_get_news（2026-08-30 用户裁决「用降级」）**：东财快讯第 103 列 + 按 `stockList` 的**港交所 marketId=116** 代码 / 港股关键词过滤；工具描述**明确标注 DEGRADED/部分覆盖**（港交所 news 若无关联代码/关键词则不捕获；东财是统一 CN 金融流，非专用港股源）。live 实测（本出口）取到「浙江海亮向港交所提交上市申请」+ 多只 **A+H 双重上市**公司公告（辽港/国航/东航/迈威——均带 `116.` 港股代码）——降级确有真实港股内容。单测 5 例全绿。
+- **live 实测暴露并修复的东财参数坑（cn/hk 共患）**：`getFastNewsList` **必须带 `sortEnd`（空串即可）与 `req_trace=1`**，否则返回 `data:null`（"Required String parameter 'sortEnd'/'req_trace' is not present"）。mock 测试不校验 URL 参数故未捕获，**真网络复测才暴露**——东财这类参数坑应入复制手册注意项。
+- **另一个 live 暴露并修复的契约坑**：东财 `stockList` 是**字符串数组 `<marketId>.<code>`**（如 `'1.600519'`/`'116.00700'`/`'105.AMZN'`），非对象数组；`relatedCodes` 保留全串，匹配时取 `.` 后 code 段（cn 按 code、hk 额外要求 `116.` 前缀）。
+- `#6` 保持开放作跟踪伞；hk 已按降级交付（不再阻塞），WS4 剩余为基本面（#2）、衍生品（#3）。
+- 全量 `pnpm -r build`/`-r test` 由 PR CI 承接；本地已对 kit-crypto（16）、kit-us（6）、kit-cn（4）、kit-hk（5）验证。
+

--- a/packages/kit-cn/test/news.test.ts
+++ b/packages/kit-cn/test/news.test.ts
@@ -16,7 +16,7 @@ const failResp = (status: number, body = 'boom'): Resp => ({ ok: false, status, 
 const eastmoneyJson = {
   data: {
     fastNewsList: [
-      { title: '贵州茅台发布半年度业绩', showTime: '2026-08-30 19:00:00', code: '202608300001', summary: '【正文】...', stockList: [{ code: '600519' }] },
+      { title: '贵州茅台发布半年度业绩', showTime: '2026-08-30 19:00:00', code: '202608300001', summary: '【正文】...', stockList: ['1.600519'] },
       { title: '沪指收盘涨0.5%', showTime: '2026-08-29 15:00:00', code: '202608290002', summary: '【正文】...' },
     ],
   },

--- a/packages/kit-hk/package.json
+++ b/packages/kit-hk/package.json
@@ -23,6 +23,7 @@
   "peerDependencies": {
     "@deepseek-ai/cordis": ">=4.0.0",
     "@deepseek-ai/dsh-skill": ">=0.1.2-alpha.1",
+    "@deepseek-ai/dsh-tools": ">=0.1.2-alpha.1",
     "@deepseek-ai/schemastery": ">=3.18.0"
   },
   "devDependencies": {

--- a/packages/kit-hk/src/index.ts
+++ b/packages/kit-hk/src/index.ts
@@ -21,6 +21,8 @@ import {
   type SkillDefinition,
   type SkillProvider,
 } from '@deepseek-ai/dsh-skill'
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import { aggregateNews, type AggregateNewsOptions } from './news.js'
 
 // ── skill provider ────────────────────────────────────────────────────────────
 
@@ -74,7 +76,7 @@ export const Config: Schema<Config> = Schema.object({
 })
 
 /** 需要宿主提供的 Cordis 服务。 */
-export const inject = ['skills']
+export const inject = ['skills', 'tools']
 
 /**
  * Cordis 插件名 = preset 行 id（TEMPLATES §8）：`dsh-trading-hk-*` 市场命名空间，
@@ -86,4 +88,83 @@ export const name = 'dsh-trading-hk-kit'
 
 export function apply(ctx: Context, _config: Config): void {
   ctx.skills.registerProvider(() => provider)
+
+  // WS4 #1（#6）：hk_get_news——降级方案（用户裁决 2026-08-30）：东财快讯第 103 列 + 116. 港股代码/关键词过滤，
+  // 诚实标注覆盖不纯（统一 CN 金融流、无干净港股公共源）。铁律 #5 只引元数据，不取正文。
+  const newsTool = createGetNewsTool()
+  const tools = ctx.tools as unknown as {
+    register(definition: { name: string }): unknown
+    get(name: string): { name: string } | undefined
+  }
+  if (tools.get(newsTool.name) !== undefined) {
+    ctx.logger('dsh-trading-hk-kit').info(
+      '[dsh-trading-hk-kit] tool %s already registered by another provider — skipped (mutual exclusion)',
+      newsTool.name,
+    )
+    return
+  }
+  tools.register(newsTool)
+}
+
+/* ── hk_get_news：港股新闻工具（WS4 #1，#6 降级） ────────────────────────────── */
+
+const DEFAULT_NEWS_WINDOW_HOURS = 24
+const DEFAULT_NEWS_LIMIT = 20
+
+function renderNewsItem(item: { source: string; title: string; url: string; publishedAt: string }): string {
+  return `[${item.source}] ${item.publishedAt}  ${item.title}\n  ${item.url}`
+}
+
+export function createGetNewsTool() {
+  const description =
+    'Get recent Hong Kong stock market news, derived from Eastmoney financial fast-news (HK column) filtered to HK-relevant items '
+    + '(HKEX-listed marketId=116 codes or HK keywords). '
+    + 'DEGRADED SOURCE — Eastmoney is a unified CN financial feed; HK coverage is PARTIAL (HK news without an HK-listed code or HK keyword is not captured; not a dedicated HK news source). '
+    + 'Each item carries source name (东方财富), publish time and a link for traceability; fetches metadata only, never redistributes article bodies. '
+    + 'Optionally filter by symbol (HK code, e.g. 00700 / 00700.HK) and by a time window. No credentials required.'
+  return defineTool({
+    name: 'hk_get_news',
+    description,
+    parameters: {
+      symbol: {
+        type: 'string',
+        description: 'Optional symbol to filter by, market-canonical vocabulary, e.g. 00700 or 00700.HK (Tencent). Best-effort matched against HK-listed stock codes.',
+      },
+      windowHours: {
+        type: 'number',
+        description: `Only keep items published within the last N hours (1-168, default ${DEFAULT_NEWS_WINDOW_HOURS}).`,
+        default: DEFAULT_NEWS_WINDOW_HOURS,
+      },
+      limit: {
+        type: 'number',
+        description: `Max items to return (1-50, default ${DEFAULT_NEWS_LIMIT}).`,
+        default: DEFAULT_NEWS_LIMIT,
+      },
+    },
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    async execute(raw) {
+      const args = (raw ?? {}) as { symbol?: unknown; windowHours?: unknown; limit?: unknown }
+      const options: AggregateNewsOptions = {
+        symbol: typeof args.symbol === 'string' ? args.symbol : undefined,
+        windowHours: typeof args.windowHours === 'number' ? args.windowHours : undefined,
+        limit: typeof args.limit === 'number' ? args.limit : undefined,
+      }
+      const { items, unavailable } = await aggregateNews(options)
+      if (items.length === 0 && unavailable.length === 0) {
+        return 'hk_get_news: no news items found within the requested window (degraded source: Eastmoney HK column may have no HK-relevant items in-window).'
+      }
+      const symbolNote = options.symbol ? ` symbol=${options.symbol.trim()}` : ''
+      const lines = [
+        `hk_get_news — ${items.length} item(s)${symbolNote}, window=${options.windowHours ?? DEFAULT_NEWS_WINDOW_HOURS}h (newest-first; DEGRADED — Eastmoney HK column, partial HK coverage):`,
+        ...items.map(renderNewsItem),
+      ]
+      if (unavailable.length > 0) {
+        lines.push('  (source(s) unavailable this call: ' + unavailable.join('; ') + ')')
+      }
+      return lines.join('\n')
+    },
+  })
 }

--- a/packages/kit-hk/src/news.ts
+++ b/packages/kit-hk/src/news.ts
@@ -1,36 +1,28 @@
 /**
- * cn_get_news 取数层（WS4 #1：#6 子工作流，spike/s impl-uscnhk-news EVIDENCE 推荐）。
+ * hk_get_news 取数层（WS4 #1：#6 子工作流；spike EVIDENCE 判定 hk 无干净公共源 → 采用「降级」方案）。
  *
- * cn 主源 = 东方财富快讯 API（本出口 200 无 key；新浪/财联社不可用，spike C/D 级）：
- *   GET np-listapi.eastmoney.com/comm/web/getFastNewsList?fastColumn=102
- * 字段：fastNewsList[] = { title, showTime(YYYY-MM-DD HH:MM:SS, 东八区), code, summary(正文) }；
- * url 由 code 构造 finance.eastmoney.com/a/<code>.html（实测可达）。
- * 铁律 #5：summary 是正文，**只引 title/showTime/链接**（元数据），不取 summary 再分发。
- * 每源失败 fail-soft（unavailable 注明）；时间窗/标的过滤 + 排序截尾；defineTool 在 index.ts。
+ * 降级口径（用户裁决 2026-08-30）：用东方财富快讯第 103 列（「港股」列，但实为统一 CN 金融流、覆盖不纯），
+ * 客户端按 `stockList` 中的**港交所 marketId=116** 代码 + 标题港股关键词过滤出港股相关标的新闻。诚实标注：
+ * 覆盖**部分**（港股新闻若不带港股关联代码/关键词则不捕获），非专用港股新闻源；与 CryptoPanic 的降级同理。
+ *
+ * 铁律 #5：只引 title/showTime/链接（元数据），不取 summary/正文，不再分发。每源失败 fail-soft。
  */
 export type NewsSource = 'eastmoney'
 
 export interface NewsItem {
-  /** 来源名（铁律 #5 的来源标注）。 */
   source: string
   title: string
   url: string
-  /** ISO 8601 发布时间（东八区换算）。 */
   publishedAt: string
-  /** 关联股票代码（东财快讯 stockList，供 symbol 过滤）。 */
   relatedCodes?: string[]
 }
 
 export interface AggregateNewsOptions {
-  /** 标的（市场规范词汇，如 600519 / 600519.SH）；缺省 = 不过滤。 */
+  /** 标的（市场规范词汇，如 00700 / 00700.HK / 0700）；缺省 = 不过滤。 */
   symbol?: string
-  /** 时间窗（小时）：只保留 now - windowHours 内的条目；缺省 24。 */
   windowHours?: number
-  /** 输出条数上限；缺省 20。 */
   limit?: number
-  /** 依赖注入的 fetch（测试用 mock；缺省 globalThis.fetch）。 */
   fetch?: typeof globalThis.fetch
-  /** 注入当前时间戳（ms，测试用）；缺省 Date.now()。 */
   now?: number
 }
 
@@ -43,30 +35,39 @@ const EASTMONEY_URL = 'https://np-listapi.eastmoney.com/comm/web/getFastNewsList
 const DEFAULT_WINDOW_HOURS = 24
 const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 50
-const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (dsh-trading/cn_get_news)'
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (dsh-trading/hk_get_news)'
+/** 港交所 marketId（stockList 前缀，如 '116.00700'）。 */
+const HK_MARKET_ID = '116.'
+/** 港股关键词（无关联代码时仍判为港股相关）。 */
+const HK_KEYWORDS = ['港股', '港交所', '香港', '恒指', '恒生']
 
 interface EastmoneyItem {
   title?: string
   showTime?: string
   code?: string | number
-  /** 东财快讯关联标的：字符串数组 `<marketId>.<code>`（如 '1.600519'=SH、'116.02493'=HK、'105.AMZN'=US）。 */
   stockList?: string[]
 }
 
-/** 东财 showTime（YYYY-MM-DD HH:MM:SS，东八区无时区后缀）→ ISO。 */
-export function parseCnShowTime(showTime: string): number {
+export function parseHkShowTime(showTime: string): number {
   const t = Date.parse(showTime.trim().replace(' ', 'T') + '+08:00')
   return Number.isFinite(t) ? t : NaN
 }
 
-async function fetchEastmoney(fetchImpl: typeof globalThis.fetch, limit: number): Promise<NewsItem[]> {
+/** 港股相关性：stockList 含 116. 前缀代码（港交所），或 title 含港股关键词。 */
+export function isHkRelevant(item: { title: string; relatedCodes?: string[] }): boolean {
+  if (item.relatedCodes?.some((c) => c.startsWith(HK_MARKET_ID))) return true
+  const title = item.title.toUpperCase()
+  return HK_KEYWORDS.some((k) => title.includes(k.toUpperCase()))
+}
+
+async function fetchEastmoneyHk(fetchImpl: typeof globalThis.fetch, limit: number): Promise<NewsItem[]> {
   const url = new URL(EASTMONEY_URL)
   url.searchParams.set('client', 'web')
   url.searchParams.set('biz', 'web_724')
   url.searchParams.set('sortEnd', '')
   url.searchParams.set('req_trace', '1')
-  url.searchParams.set('fastColumn', '102')
-  url.searchParams.set('pageSize', String(Math.max(limit, 20)))
+  url.searchParams.set('fastColumn', '103')
+  url.searchParams.set('pageSize', String(Math.max(limit * 2, 40)))
   const response = await fetchImpl(url, { headers: { accept: 'application/json', 'user-agent': UA } })
   if (!response.ok) {
     const body = await response.text().catch(() => '')
@@ -78,19 +79,22 @@ async function fetchEastmoney(fetchImpl: typeof globalThis.fetch, limit: number)
   const items: NewsItem[] = []
   for (const it of list) {
     if (!it.title || it.code === undefined) continue
-    const ts = typeof it.showTime === 'string' ? parseCnShowTime(it.showTime) : NaN
+    const ts = typeof it.showTime === 'string' ? parseHkShowTime(it.showTime) : NaN
     if (!Number.isFinite(ts)) continue
-    // relatedCodes 保留完整 `<marketId>.<code>`（如 '1.600519'/'116.00700'），匹配时取 code 段。
     const relatedCodes = Array.isArray(it.stockList)
       ? it.stockList.filter((s) => typeof s === 'string' && s.includes('.'))
       : undefined
-    items.push({
+    const candidate: NewsItem = {
       source: 'eastmoney',
       title: it.title,
       url: `https://finance.eastmoney.com/a/${encodeURIComponent(String(it.code))}.html`,
       publishedAt: new Date(ts).toISOString(),
       ...(relatedCodes && relatedCodes.length > 0 ? { relatedCodes } : {}),
-    })
+    }
+    // 降级：仅保留港股相关信息（116. 代码 或 港股关键词）。
+    if (isHkRelevant(candidate)) {
+      items.push(candidate)
+    }
   }
   return items
 }
@@ -105,15 +109,13 @@ function matchesSymbol(item: NewsItem, rawSymbol?: string): boolean {
   const needle = rawSymbol?.trim()
   if (!needle) return true
   const title = item.title.toUpperCase()
-  const base = needle.replace(/\.(SH|SZ|BJ)$/i, '')
-  // cn 标题常用公司中文名（贵州茅台）非代码（600519）——先按代码匹配标题或关联股票代码（stockList），
-  // 中文名匹配是已知局限（不隐式建名称映射）。
-  const tokens = [needle.toUpperCase(), base.toUpperCase()]
+  // hk 符号规范：00700 / 00700.HK / 0700（补零归一化 5 位）。
+  const normalizedNeedle = needle.toUpperCase().replace(/\.HK$/i, '').replace(/^0+/, '')
+  const tokens = [needle.toUpperCase(), normalizedNeedle]
   if (tokens.some((t) => t && title.includes(t))) return true
   if (item.relatedCodes) {
-    // 东财 code = `<marketId>.<code>`；按 . 后 code 段匹配（'1.600519' → '600519'）。
-    const codes = item.relatedCodes.map((c) => c.split('.').slice(-1)[0].toUpperCase())
-    return tokens.some((t) => t && codes.includes(t))
+    // 港股代码：`116.00700` → 匹配 116. 前缀 + 去前导零后的 code 段（00700 → 00700）。
+    return tokens.some((t) => t && item.relatedCodes!.some((c) => c.startsWith('116.') && c.slice(4).replace(/^0+/, '') === t))
   }
   return false
 }
@@ -130,7 +132,7 @@ export async function aggregateNews(options: AggregateNewsOptions = {}): Promise
   const windowMs = windowHours * 3_600_000
   const limit = clampNumber(options.limit, DEFAULT_LIMIT, 1, MAX_LIMIT)
 
-  const results = await Promise.allSettled([fetchEastmoney(fetchImpl, limit)])
+  const results = await Promise.allSettled([fetchEastmoneyHk(fetchImpl, limit)])
 
   const items: NewsItem[] = []
   const unavailable: string[] = []

--- a/packages/kit-hk/test/news.test.ts
+++ b/packages/kit-hk/test/news.test.ts
@@ -1,0 +1,77 @@
+/**
+ * hk_get_news 取数层/工具单测（WS4 #1：#6 降级方案——东财快讯 HK 列按 116. 港股代码/关键词过滤）。
+ * mock fetch，不触真实网络。覆盖：港股相关性过滤、symbol 过滤（00700）、时间窗、降级/fail-soft、工具壳渲染。
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { aggregateNews, isHkRelevant, parseHkShowTime } from '../src/news.ts'
+import { createGetNewsTool } from '../src/index.ts'
+
+const NOW = Date.parse('2026-08-30T20:00:00Z')
+
+type Resp = { ok: boolean; status: number; text: () => Promise<string> }
+const jsonResp = (obj: unknown): Resp => ({ ok: true, status: 200, text: async () => JSON.stringify(obj) })
+const failResp = (status: number, body = 'boom'): Resp => ({ ok: false, status, text: async () => body })
+
+const eastmoneyHkJson = {
+  data: {
+    fastNewsList: [
+      { title: '腾讯控股回购股份', showTime: '2026-08-30 19:00:00', code: '202608300001', summary: 'x', stockList: ['116.00700'] },
+      { title: '阿里健康发布中期业绩', showTime: '2026-08-30 18:00:00', code: '202608300002', summary: 'x', stockList: ['116.00241'] },
+      { title: '贵州茅台发布半年度业绩', showTime: '2026-08-30 17:00:00', code: '202608300003', summary: 'x', stockList: ['1.600519'] },
+      { title: '港交所拟优化上市制度', showTime: '2026-08-30 16:00:00', code: '202608300004', summary: 'x', stockList: [] },
+    ],
+  },
+}
+
+const mockFetch = (resp: Resp) => vi.fn(async () => resp) as unknown as typeof globalThis.fetch
+
+afterEach(() => { vi.unstubAllGlobals() })
+
+describe('isHkRelevant（港股相关性：116. 代码 或 港股关键词）', () => {
+  it('命中 116. 前缀代码或港股关键词；A 股/无前缀代码不命中', () => {
+    expect(isHkRelevant({ title: '腾讯控股回购', relatedCodes: ['116.00700'] })).toBe(true)
+    expect(isHkRelevant({ title: '港交所优化制度', relatedCodes: [] })).toBe(true) // 关键词
+    expect(isHkRelevant({ title: '贵州茅台', relatedCodes: ['1.600519'] })).toBe(false) // A 股
+  })
+})
+
+describe('parseHkShowTime（东八区 → ISO 毫秒）', () => {
+  it('解析无时区后缀 showTime', () => {
+    expect(parseHkShowTime('2026-08-30 19:00:00')).toBe(Date.parse('2026-08-30T19:00:00+08:00'))
+  })
+})
+
+describe('aggregateNews（东财 HK 列 + 港股过滤 + symbol + 降级）', () => {
+  it('只保留港股相关项：116. 代码项（腾讯/阿里健康）+ 关键词项（港交所）；A 股项被滤', async () => {
+    const { items, unavailable } = await aggregateNews({ fetch: mockFetch(jsonResp(eastmoneyHkJson)), now: NOW })
+    expect(unavailable).toEqual([])
+    const titles = items.map((i) => i.title)
+    expect(titles).toContain('腾讯控股回购股份')
+    expect(titles).toContain('阿里健康发布中期业绩')
+    expect(titles).toContain('港交所拟优化上市制度')
+    expect(titles).not.toContain('贵州茅台发布半年度业绩') // A 股 (1.) 被滤
+  })
+
+  it('symbol 过滤：00700（补零归一化）命中腾讯 116.00700；单源失败 fail-soft', async () => {
+    const { items } = await aggregateNews({ fetch: mockFetch(jsonResp(eastmoneyHkJson)), now: NOW, symbol: '00700' })
+    expect(items.map((i) => i.title)).toContain('腾讯控股回购股份')
+    const failed = await aggregateNews({ fetch: mockFetch(failResp(500)), now: NOW })
+    expect(failed.unavailable.some((u) => u.includes('eastmoney'))).toBe(true)
+    expect(failed.items).toHaveLength(0)
+  })
+})
+
+describe('createGetNewsTool（工具壳）', () => {
+  it('execute 渲染：含 DEGRADED 标注、来源、链接', async () => {
+    const base = Date.now() - 1_800_000
+    const near = { data: { fastNewsList: [{ title: '腾讯控股回购', showTime: new Date(base).toISOString().slice(0, 19).replace('T', ' '), code: '202608300001', summary: 'x', stockList: ['116.00700'] }] } }
+    vi.stubGlobal('fetch', mockFetch(jsonResp(near)))
+    const tool = createGetNewsTool()
+    expect(tool.name).toBe('hk_get_news')
+    const text = await tool.execute({ windowHours: 24, limit: 10 }) as string
+    expect(text).toContain('hk_get_news — ')
+    expect(text).toContain('DEGRADED')
+    expect(text).toContain('[eastmoney]')
+    expect(text).toContain('https://finance.eastmoney.com/a/202608300001.html')
+  })
+})


### PR DESCRIPTION
Part of #6（WS4 #1「us/cn/hk 新闻源」——**hk 按你的降级裁决交付**；叠在 [PR #11](https://github.com/zhu1090093659/dsh-trading/pull/11) 上）。

## 交付内容

- **`hk_get_news`**（kit-hk）：东财快讯第 103 列 + 按 `stockList` 的**港交所 marketId=116** 代码 / 港股关键词过滤出港股相关新闻；工具描述**明确标注 DEGRADED / 部分覆盖**（东财是统一 CN 金融流，无干净港股公共源——你说的降级方案）。
- **修复 cn(#11) 的东财必填参数坑（live 暴露）**：`getFastNewsList` **必须带 `sortEnd`（空串）与 `req_trace=1`**，否则返回 `data:null`。cn/hk 均补上。
- **修复 cn 的 stockList 契约**：东财 `stockList` 是**字符串数组 `<marketId>.<code>`**（`'1.600519'`/`'116.00700'`）非对象数组——`relatedCodes` 保留全串、匹配取 `.` 后 code 段（cn 按 code、hk 额外要求 `116.` 前缀）。

## 验证

- 单测：cn 4 / hk 5 全绿；三 kit tsdown 均 3 文件干净构建（vendor 未内联）。
- **降级 live 实测（本出口，无 mock）**：hk 取到「浙江海亮向港交所提交上市申请」+ 多只 **A+H 双重上市**公司公告（辽港/国航/东航/迈威——均带 `116.` 港股代码），cn 取到 A 股快讯——证明降级确有真实港股内容，覆盖不纯但可用。

## 诚实边界

- hk 覆盖**部分**：港交所 news 若无关联港股代码/关键词则不捕获；东财港股列仍混 A 股（降级语义，工具 description 明示）。
- 修复 #11 的两个东财契约/参数坑在 mock 测试下不暴露（不校验 URL），**真网络复测才抓到**——已入 Agent Note 提醒复制注意。

@zhu1090093659 请连同 #11 审；#6 的 us/cn/hk 新闻（#1）至此 us/cn 干净实现 + hk 降级交付，剩余 WS4 基本面子项与衍生品另议。