### PR TITLE
chore: 清理 root package.json 重复的 sync:skills 键

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "sync:skills": "node scripts/sync-skills.mjs",
     "build": "pnpm sync:skills && pnpm -r build",
     "test": "vitest run --passWithNoTests",
-    "sync:skills": "node scripts/sync-skills.mjs",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm build && changeset publish"


### PR DESCRIPTION
PR #49 收尾时的观察项：root package.json scripts 里 `sync:skills` 定义了两次（同值），esbuild 在每次 CI 测试转译中发 `duplicate-object-key` 警告。保留首个定义删除重复行。

**验证**：本地先复现警告（`pnpm --filter @dsh-trading/client-ui-knowledge test`）→ 修复后同命令 0 条警告；`pnpm build` 无错、`pnpm test` 711 passed。