### PR TITLE
fix(trade): Alpaca/Futu 实盘语义、回执契约与 watchlist 并发持久化修复（issue #58）

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-03-issue58-live-semantics-watchlist-rmw.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-03-issue58-live-semantics-watchlist-rmw.md
@@ -1,0 +1,73 @@
+# Agent Note: issue #58 实盘语义与 watchlist 并发持久化修复
+
+Status: implemented (PR 待审查批准)
+
+## Problem
+
+协作者 tianhaishun 审计（基线 main@0e27941，PR #57 合并后）报 5 项发现（issue #58），
+逐条对码核实全部成立：
+
+1. `us_place_order`/`hk_place_order` 过 live 闸门后调 `trade.placeOrder` **未传
+   `dryRun:false`**——服务层 `dryRun ?? true` 把实盘单静默降级为模拟单（工具说 live、
+   券商收模拟）；同时把大写 `BUY`/`MARKET` 直接塞进 OrderRequest（契约
+   `OrderSide='buy'|'sell'`、`OrderType='limit'|'market'`）。
+2. `AlpacaRestClient.cancelOrder` catch 后对非 404 异常不 rethrow——401/429/网络/
+   5xx 全部吞掉，上层误报撤单成功。
+3. `FutuRestClient.getBalance` 返回 `{currency,available,total}`，契约是
+   `AccountBalance={asset,free,locked}`——GUI 只读账户面按 `.free/.locked` 读全为
+   undefined；`placeOrder` 回执大写 side/type 且**缺 `dryRun`**（回执必须显式回带）。
+4. `connector-futu/src/dataplane.ts` 用旧签名构造 `FutuTradeService`
+   （`{gatewayUrl,config}` + getCredentials 函数）——现行签名是
+   `(ctx,{client,config},serviceName?)`，`options.client` 为 undefined，交易面一调即崩。
+5. `watchlist/file-store.ts` 只有写盘入队，`add`/`remove` 的读改写在队外——并发写
+   后写覆盖先写丢更新。
+
+对照：OKX 工具 live 路径显式传 `dryRun:false`（仓内正确样板）；Binance 本切片
+live 未实现直接拒绝，均不在洞内。
+
+## Decision
+
+- **修工具层边界**（发现 1）：live 分支传 `dryRun:false` + 小写 side/type 映射，
+  agent 工具面（大写枚举词汇）不变；服务缝闸门三态检查不动（铁律 #3 双保险结构保留）。
+- **cancelOrder 幂等收窄**（发现 2）：仅 404（TRADING_UNSUPPORTED_SYMBOL 载荷，
+  request 层的 not-found 载体）视作成功，其余原样上抛。
+- **Futu 客户端回契**（发现 3）：getBalance 映射
+  `{asset: currency??'HKD', free: cash, locked: frozenCash??0}`；placeOrder 回执
+  小写 side/type + `dryRun:false`。
+- **dataplane 换现行签名**（发现 4）：`new FutuRestClient({gatewayUrl})` 进
+  `{client, config}`，删旧第三参；gatewayUrl 经 client 生效。
+- **RMW 全程入队**（发现 5）：`add`/`remove` 整体 `enqueue`，新增 `writeNow`
+  供队内直写——**写盘不能二次入队**（内层 enqueue 链到外层自身，自等死锁）；
+  selection store 无读改写，保持 last-write-wins 不动。
+
+## Gotchas
+
+- **tsdown build 不查类型**是这批契约漂移能存活的原因：futu 余额/回执/dataplane
+  构造错型全靠 typecheck 棘轮兜底。本轮修复后棘轮 515 → **510**（-5，还债），CI 侧
+  build 后 test 前跑 gate 的顺序不能省。
+- 验证「新测试咬合旧实现」时用 `git checkout -- <path>` 还原旧版——**把自己未提交的
+  修复一并冲掉了**（worktree 内 HEAD 即旧版）。教训：并行开发纪律「WIP 尽早提交」
+  在做对照实验前同样成立，先 commit 再 checkout 对照。
+
+## Validation
+
+- 定向：connector-alpaca 16、connector-futu 8、watchlist 10 全绿；新增测试含
+  cancelOrder 404/429/401/网络四态、两工具 live 路径契约断言（spy 断言
+  `dryRun:false` + 小写）、并发 add 四行不丢 + 同 symbol 去重。
+- 咬合度：旧 file-store 实现下并发两测**确实变红**（2 failed），修复后复绿。
+- 全量：`pnpm build` 绿；typecheck-gate 510 ≤ 515；`pnpm i18n:check` OK；
+  `pnpm test` 875 passed | 2 skipped（基线 866 + 新增 9）。
+
+## Files
+
+- `packages/connector-alpaca/src/index.ts`（工具 live 路径）、`src/rest.ts`
+  （cancelOrder rethrow）、`test/template.test.ts`（+6 测）
+- `packages/connector-futu/src/index.ts`（同发现 1）、`src/rest.ts`（余额/回执契约）、
+  `src/dataplane.ts`（现行构造签名）、`test/template.test.ts`（断言更新 + 新测）
+- `packages/watchlist/src/file-store.ts`（RMW 入队）、`test/watchlist.test.ts`（+2 并发测）
+
+## 遗留
+
+- `FutuTradeService.getOrder` 仍返回捏造桩值（`{side:'buy',type:'limit',status:'new',
+  quantity:0}`）——审计未列、真实 getOrder 需 OpenD 回单查询链路，超出本轮最小修复。
+- 提交者自述「本地补丁尚未推送」：本 PR 合并后请其对比弃取，避免重复劳动。

--- a/packages/connector-alpaca/src/index.ts
+++ b/packages/connector-alpaca/src/index.ts
@@ -359,10 +359,11 @@ export function createPlaceOrderTool(deps: { marketData: Pick<MarketDataService,
       }
       const order = await deps.trade.placeOrder({
         symbol: args.symbol,
-        side: args.side,
-        type: args.type,
+        side: args.side === 'SELL' ? 'sell' : 'buy',
+        type: args.type === 'LIMIT' ? 'limit' : 'market',
         quantity: args.quantity,
         price: args.price,
+        dryRun: false,
       })
       return JSON.stringify(order)
     },

--- a/packages/connector-alpaca/src/rest.ts
+++ b/packages/connector-alpaca/src/rest.ts
@@ -366,8 +366,10 @@ export class AlpacaRestClient {
     try {
       await this.request(this.tradingBaseUrl, `/orders/${orderId}`, { method: 'DELETE' }, credentials)
     } catch (err) {
-      // 幂等：若已终态或未找到则视作成功
+      // 幂等：仅 404（订单不存在/已终态）视作撤销成功；401/429/网络/5xx 等
+      // 一律原样上抛，上层不得误报撤单成功（issue #58）。
       if (err instanceof TradingServiceError && err.code === 'TRADING_UNSUPPORTED_SYMBOL') return
+      throw err
     }
   }
 

--- a/packages/connector-alpaca/test/template.test.ts
+++ b/packages/connector-alpaca/test/template.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
+import type { TradeService } from '@dshtrading/api'
 import {
   AlpacaRestClient,
   INTERVAL_VOCABULARY,
   TradingServiceError,
   normalizeUsSymbol,
 } from '../src/rest.js'
+import { createPlaceOrderTool, type Config } from '../src/index.js'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -177,3 +179,92 @@ describe('AlpacaRestClient.placeOrder / getBalance', () => {
 })
 
 
+
+describe('AlpacaRestClient.cancelOrder（issue #58）', () => {
+  const creds = { key: 'test_k', secret: 'test_s' }
+
+  it('404（订单不存在/已终态）幂等视作成功', async () => {
+    const { impl } = stubFetch([
+      { match: '/orders/ord-1', body: { message: 'not found' }, status: 404 },
+    ])
+    const client = new AlpacaRestClient({ fetchImpl: impl })
+    await expect(client.cancelOrder(creds, 'ord-1')).resolves.toBeUndefined()
+  })
+
+  it('429 限流原样上抛，不得误报撤单成功', async () => {
+    const { impl } = stubFetch([
+      { match: '/orders/ord-2', body: { message: 'too many requests' }, status: 429 },
+    ])
+    const client = new AlpacaRestClient({ fetchImpl: impl })
+    await expect(client.cancelOrder(creds, 'ord-2')).rejects.toMatchObject({ code: 'TRADING_RATE_LIMITED' })
+  })
+
+  it('401 认证失败原样上抛', async () => {
+    const { impl } = stubFetch([
+      { match: '/orders/ord-3', body: { message: 'bad key' }, status: 401 },
+    ])
+    const client = new AlpacaRestClient({ fetchImpl: impl })
+    await expect(client.cancelOrder(creds, 'ord-3')).rejects.toMatchObject({ code: 'TRADING_AUTH_FAILED' })
+  })
+
+  it('网络错误原样上抛', async () => {
+    const impl = (async () => {
+      throw new Error('network down')
+    }) as typeof fetch
+    const client = new AlpacaRestClient({ fetchImpl: impl })
+    await expect(client.cancelOrder(creds, 'ord-4')).rejects.toThrow('network down')
+  })
+})
+
+describe('us_place_order 工具 live 路径（issue #58）', () => {
+  const config = {
+    enabled: true,
+    env: 'live',
+    dryRun: false,
+    liveTrading: true,
+    apiKeyRef: 'K',
+    secretRef: 'S',
+    demoApiKeyRef: 'DK',
+    demoSecretRef: 'DS',
+  } as Config
+
+  it('过 live 闸门后以 OrderRequest 契约调服务：小写 side/type + dryRun:false', async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const trade = {
+      placeOrder: async (order: Record<string, unknown>) => {
+        calls.push(order)
+        return { id: 'live-1', dryRun: false, status: 'new', ...order }
+      },
+    } as unknown as TradeService
+    const tool = createPlaceOrderTool({
+      marketData: { getTicker: async () => { throw new Error('live 路径不得查询参照价') } },
+      trade,
+      config,
+    })
+    const out = JSON.parse(String(await tool.execute({
+      symbol: 'AAPL', side: 'SELL', type: 'LIMIT', quantity: 10, price: 220, dryRun: false,
+    }))) as { id: string; dryRun: boolean }
+    expect(out.id).toBe('live-1')
+    expect(out.dryRun).toBe(false)
+    expect(calls[0]).toMatchObject({
+      symbol: 'AAPL',
+      side: 'sell',
+      type: 'limit',
+      quantity: 10,
+      price: 220,
+      dryRun: false,
+    })
+  })
+
+  it('liveTrading=false 时 dryRun:false 仍在工具闸门被拒', async () => {
+    const tool = createPlaceOrderTool({
+      marketData: { getTicker: async () => { throw new Error('unreachable') } },
+      config: { ...config, liveTrading: false },
+    })
+    const out = JSON.parse(String(await tool.execute({
+      symbol: 'AAPL', side: 'BUY', type: 'MARKET', quantity: 1, dryRun: false,
+    }))) as { status: string; code: string }
+    expect(out.status).toBe('rejected')
+    expect(out.code).toBe('TRADING_LIVE_TRADING_DISABLED')
+  })
+})

--- a/packages/connector-futu/src/dataplane.ts
+++ b/packages/connector-futu/src/dataplane.ts
@@ -16,6 +16,7 @@ import type { Context } from '@deepseek-ai/cordis'
 import type { MarketDataService, TradeRegistry } from '@dshtrading/api'
 import {
   FutuMarketDataService,
+  FutuRestClient,
   FutuTradeService,
   TRADING_HK_MARKET_DATA_KEY,
   TRADING_HK_TRADE_KEY,
@@ -59,10 +60,12 @@ export function apply(ctx: Context, config: Config): void {
   const tradeRegistry = resolveTradeRegistry(ctx)
   if (tradeRegistry !== undefined) {
     const tradeInner = ctx.isolate(TRADING_HK_TRADE_KEY)
+    // 现行构造签名 (ctx, { client, config }, serviceName?)（issue #58）：旧调用传
+    // { gatewayUrl, config } + getCredentials 函数，options.client 为 undefined，
+    // 交易面一调用即崩；gatewayUrl 经 FutuRestClient 传入。
     const trade = new FutuTradeService(
       tradeInner,
-      { gatewayUrl: config.gatewayUrl, config },
-      async () => ({ unlockPwd: process.env[config.unlockPwdRef] }),
+      { client: new FutuRestClient({ gatewayUrl: config.gatewayUrl }), config },
     )
     ctx.effect(() => tradeRegistry.register(MARKET, ROUTER_PROVIDER, trade))
   }

--- a/packages/connector-futu/src/index.ts
+++ b/packages/connector-futu/src/index.ts
@@ -274,10 +274,11 @@ export function createPlaceOrderTool(deps: { marketData: Pick<MarketDataService,
       }
       const order = await deps.trade.placeOrder({
         symbol: args.symbol,
-        side: args.side,
-        type: args.type,
+        side: args.side === 'SELL' ? 'sell' : 'buy',
+        type: args.type === 'LIMIT' ? 'limit' : 'market',
         quantity: args.quantity,
         price: args.price,
+        dryRun: false,
       })
       return JSON.stringify(order)
     },

--- a/packages/connector-futu/src/rest.ts
+++ b/packages/connector-futu/src/rest.ts
@@ -214,11 +214,13 @@ export class FutuRestClient {
   }
 
   async getBalance(_credentials?: FutuCredentials): Promise<AccountBalance> {
-    const data = await this.request<{ cash?: number; totalAssets?: number; currency?: string }>('/api/trd/get-funds')
+    const data = await this.request<{ cash?: number; frozenCash?: number; totalAssets?: number; currency?: string }>('/api/trd/get-funds')
+    // 契约形状 AccountBalance { asset, free, locked }（issue #58）：此前返回
+    // currency/available/total 三键，消费方按 .free/.locked 读全为 undefined。
     return {
-      currency: data.currency ?? 'HKD',
-      available: Number(data.cash ?? 0),
-      total: Number(data.totalAssets ?? 0),
+      asset: data.currency ?? 'HKD',
+      free: Number(data.cash ?? 0),
+      locked: Number(data.frozenCash ?? 0),
     }
   }
 
@@ -234,14 +236,17 @@ export class FutuRestClient {
     })
 
     const id = data.orderId ?? data.orderID ?? `futu-${Date.now()}`
+    // 真实回执：side/type 落 OrderSide/OrderType 契约词汇，dryRun 显式回带 false
+    // （回执必须显式回带，防 dry-run 语义丢失；issue #58）。
     return {
       id,
       symbol: canonical,
-      side: req.side,
-      type: req.type,
+      side: req.side === 'SELL' ? 'sell' : 'buy',
+      type: req.type === 'LIMIT' ? 'limit' : 'market',
       quantity: req.quantity,
       price: req.price,
       status: 'new',
+      dryRun: false,
       timestamp: Date.now(),
     }
   }

--- a/packages/connector-futu/test/template.test.ts
+++ b/packages/connector-futu/test/template.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { TradeService } from '@dshtrading/api'
 import {
   FutuRestClient,
   INTERVAL_VOCABULARY,
@@ -6,6 +7,7 @@ import {
   normalizeHkSymbol,
   toFutuSecurity,
 } from '../src/rest.js'
+import { createPlaceOrderTool, type Config } from '../src/index.js'
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -120,20 +122,20 @@ describe('FutuRestClient.getKlines', () => {
 })
 
 describe('FutuRestClient.getBalance / placeOrder', () => {
-  it('获取港股资产账户余额', async () => {
+  it('获取港股资产账户余额（AccountBalance 契约形状，issue #58）', async () => {
     const { impl } = stubFetch([
-      { match: '/api/trd/get-funds', body: { retType: 0, data: { currency: 'HKD', cash: 200000, totalAssets: 500000 } } },
+      { match: '/api/trd/get-funds', body: { retType: 0, data: { currency: 'HKD', cash: 200000, frozenCash: 50000, totalAssets: 500000 } } },
     ])
     const client = new FutuRestClient({ fetchImpl: impl })
     const balance = await client.getBalance()
     expect(balance).toEqual({
-      currency: 'HKD',
-      available: 200000,
-      total: 500000,
+      asset: 'HKD',
+      free: 200000,
+      locked: 50000,
     })
   })
 
-  it('港股下单并返回 Order', async () => {
+  it('港股下单并返回 Order（小写 side/type + dryRun:false 回带，issue #58）', async () => {
     const { impl, urls } = stubFetch([
       { match: '/api/trd/place-order', body: { retType: 0, data: { orderId: 'futu-ord-999' } } },
     ])
@@ -150,9 +152,49 @@ describe('FutuRestClient.getBalance / placeOrder', () => {
     expect(order).toMatchObject({
       id: 'futu-ord-999',
       symbol: '00700.HK',
-      side: 'BUY',
+      side: 'buy',
+      type: 'limit',
       quantity: 100,
       price: 380,
+      dryRun: false,
+    })
+  })
+})
+
+describe('hk_place_order 工具 live 路径（issue #58）', () => {
+  const config = {
+    enabled: true,
+    gatewayUrl: 'http://127.0.0.1:11111',
+    dryRun: false,
+    liveTrading: true,
+    unlockPwdRef: 'FUTU_UNLOCK_PWD',
+  } as Config
+
+  it('过 live 闸门后以 OrderRequest 契约调服务：小写 side/type + dryRun:false', async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const trade = {
+      placeOrder: async (order: Record<string, unknown>) => {
+        calls.push(order)
+        return { id: 'live-hk-1', dryRun: false, status: 'new', ...order }
+      },
+    } as unknown as TradeService
+    const tool = createPlaceOrderTool({
+      marketData: { getTicker: async () => { throw new Error('live 路径不得查询参照价') } },
+      trade,
+      config,
+    })
+    const out = JSON.parse(String(await tool.execute({
+      symbol: '00700.HK', side: 'SELL', type: 'LIMIT', quantity: 100, price: 380, dryRun: false,
+    }))) as { id: string; dryRun: boolean }
+    expect(out.id).toBe('live-hk-1')
+    expect(out.dryRun).toBe(false)
+    expect(calls[0]).toMatchObject({
+      symbol: '00700.HK',
+      side: 'sell',
+      type: 'limit',
+      quantity: 100,
+      price: 380,
+      dryRun: false,
     })
   })
 })

--- a/packages/watchlist/src/file-store.ts
+++ b/packages/watchlist/src/file-store.ts
@@ -61,9 +61,14 @@ export function createFileWatchlistStore(filePath: string): WatchlistStore {
     return cache
   }
 
+  /** 仅在 enqueue 队列内调用：写盘不能二次入队（外层已持队，内层 enqueue 会自等死锁）。 */
+  function writeNow(map: WatchlistsMap): Promise<void> {
+    return safeAtomicWrite(filePath, JSON.stringify(map, null, 2))
+  }
+
   async function flush(map: WatchlistsMap): Promise<void> {
     return enqueue(async () => {
-      await safeAtomicWrite(filePath, JSON.stringify(map, null, 2))
+      await writeNow(map)
     })
   }
 
@@ -75,24 +80,30 @@ export function createFileWatchlistStore(filePath: string): WatchlistStore {
       cache = { ...next }
       await flush(cache)
     },
+    // 读改写全程入队串行化（issue #58）：此前只有写盘排队，两个并发 add 都从
+    // 同一旧态计算 next，后写覆盖先写丢更新；工具与 GUI 桥并发写时真实发生。
     async add(market, instrument) {
-      const map = await load()
-      const rows = map[market] ?? []
-      if (rows.some(row => row.symbol === instrument.symbol)) return false
-      const next = { ...map, [market]: [...rows, { ...instrument }] }
-      cache = next
-      await flush(next)
-      return true
+      return enqueue(async () => {
+        const map = await load()
+        const rows = map[market] ?? []
+        if (rows.some(row => row.symbol === instrument.symbol)) return false
+        const next = { ...map, [market]: [...rows, { ...instrument }] }
+        cache = next
+        await writeNow(next)
+        return true
+      })
     },
     async remove(market, symbol) {
-      const map = await load()
-      const rows = map[market] ?? []
-      const nextRows = rows.filter(row => row.symbol !== symbol)
-      if (nextRows.length === rows.length) return false
-      const next = { ...map, [market]: nextRows }
-      cache = next
-      await flush(next)
-      return true
+      return enqueue(async () => {
+        const map = await load()
+        const rows = map[market] ?? []
+        const nextRows = rows.filter(row => row.symbol !== symbol)
+        if (nextRows.length === rows.length) return false
+        const next = { ...map, [market]: nextRows }
+        cache = next
+        await writeNow(next)
+        return true
+      })
     },
   }
 }

--- a/packages/watchlist/test/watchlist.test.ts
+++ b/packages/watchlist/test/watchlist.test.ts
@@ -133,3 +133,38 @@ describe('watchlist_* tools', () => {
     expect(onSelectionChanged).toHaveBeenCalledTimes(3)
   })
 })
+
+describe('file store 并发读改写（issue #58）', () => {
+  it('并发 add 全部落盘不丢更新（RMW 全程入队串行化）', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'dsh-watchlist-'))
+    const filePath = join(dir, 'watchlists.json')
+    const store = createFileWatchlistStore(filePath)
+    const results = await Promise.all([
+      store.add('us', { market: 'us', symbol: 'AAPL' }),
+      store.add('us', { market: 'us', symbol: 'NVDA' }),
+      store.add('us', { market: 'us', symbol: 'MSFT' }),
+      store.add('crypto', { market: 'crypto', symbol: 'BTCUSDT' }),
+    ])
+    expect(results).toEqual([true, true, true, true])
+    // 新实例（空缓存）从盘上读：修复前最后一个 flush 用旧态整行覆盖，先写行丢失。
+    const reread = createFileWatchlistStore(filePath)
+    const list = await reread.list()
+    expect(list.us?.map(r => r.symbol).sort()).toEqual(['AAPL', 'MSFT', 'NVDA'])
+    expect(list.crypto?.map(r => r.symbol)).toEqual(['BTCUSDT'])
+    const files = await readdir(dir)
+    expect(files.filter(f => f.includes('.tmp.'))).toEqual([])
+  })
+
+  it('并发 add 同一 symbol 仍按去重语义只落一行', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'dsh-watchlist-'))
+    const filePath = join(dir, 'watchlists.json')
+    const store = createFileWatchlistStore(filePath)
+    const results = await Promise.all([
+      store.add('us', { market: 'us', symbol: 'AAPL' }),
+      store.add('us', { market: 'us', symbol: 'AAPL' }),
+    ])
+    expect(results.filter(Boolean)).toHaveLength(1)
+    const list = await store.list()
+    expect(list.us).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## 概述

issue #58 审计的 5 项发现逐条对码核实全部成立（基线 main@0e27941 在 PR #57 之后，发现均未过期），本轮最小补丁逐项修复。改动只落在三个包，agent 工具面参数词汇与服务缝三态闸门结构不变。

## 逐项修复

| # | 发现 | 修复 |
|---|---|---|
| 1 | `us/hk_place_order` 过 live 闸门后未传 `dryRun:false`，被服务层降级为模拟单；大写 side/type 不符 OrderRequest | live 分支显式 `dryRun:false` + 小写 side/type 映射（对齐仓内 OKX 正确样板）；工具参数词汇不变 |
| 2 | `AlpacaRestClient.cancelOrder` 吞 401/429/网络/5xx，上层误报撤单成功 | 仅 404 幂等放行（not-found 载荷），其余原样上抛 |
| 3 | Futu 余额返回 `{currency,available,total}` 不符 `AccountBalance{asset,free,locked}`；订单回执大写 side/type 且缺 `dryRun` | getBalance 按契约映射（locked 取 `frozenCash`，缺省 0）；回执小写 side/type + `dryRun:false` 显式回带 |
| 4 | Futu dataplane 用旧 TradeService 构造参数，`options.client` 为 undefined，交易面一调即崩 | 换现行签名 `(ctx,{client,config},serviceName?)`，gatewayUrl 经 `FutuRestClient` 生效 |
| 5 | watchlist file store 只串行化写盘，并发 add 读改写丢更新 | add/remove 全程入队串行化；队内直写走 `writeNow`（避免二次入队死锁）；selection 无读改写保持不动 |

范围外说明：Binance 本切片 live 未实现（直接拒绝）、OKX 工具层已正确，均无同类洞；`FutuTradeService.getOrder` 捏造桩值审计未列，需 OpenD 回单查询链路，留后续。

## 验证

- **定向**：connector-alpaca 16 / connector-futu 8 / watchlist 10 全绿；新增 cancelOrder 四态（404 幂等 / 429 / 401 / 网络）、两工具 live 路径 spy 断言（`dryRun:false` + 小写）、并发 add 不丢更新 + 同 symbol 去重。
- **咬合度**：旧 file-store 实现下新增并发两测确实变红（2 failed），修复后复绿——测试不是摆设。
- **全量**：`pnpm build` 全绿；typecheck 棘轮 **510 ≤ 基线 515**（契约修复顺带还 5 个类型债）；`pnpm i18n:check` OK；`pnpm test` **875 passed | 2 skipped**。

Fixes #58

决策记录：.agents/notes/implemented/bug-fix/2026-09-03-issue58-live-semantics-watchlist-rmw.md