### PR TITLE
feat(indicators): 图表激活名册 host SSOT——agent 可直接挂载/摘除/枚举图表指标

### DIFF
--- a/.agents/notes/implemented/feature/2026-08-31-author-custom-indicators.md
+++ b/.agents/notes/implemented/feature/2026-08-31-author-custom-indicators.md
@@ -47,3 +47,5 @@
 
 1. **编译构建**：全量 19 个 package `pnpm -r build` 100% 通过。
 2. **单元测试**：全量 `pnpm -r test` 252+ 用例全绿（涵盖坏例拦截、死循环超时熔断、TD9、SuperTrend、OBV+MA34 黄金用例、HTTP 桥端点等专项单测）。
+
+> 后续（2026-09-04）：「使用」侧最后一公里（agent 挂载/摘除/枚举图表指标）由 [indicator-agent-chart-activation](./2026-09-04-indicator-agent-chart-activation.md) 补齐，`indicator_author` 增加 `activate` 可选参数。

--- a/.agents/notes/implemented/feature/2026-09-04-indicator-agent-chart-activation.md
+++ b/.agents/notes/implemented/feature/2026-09-04-indicator-agent-chart-activation.md
@@ -1,0 +1,55 @@
+# Agent Note: 图表激活名册 host SSOT——agent 直接挂载/摘除/枚举图表指标
+
+- **日期**：2026-09-04
+- **状态**：已实现 (implemented)
+- **关联 Issue**：[#63](https://github.com/zhu1090093659/dsh-trading/issues/63)
+- **分支**：`feat/63-indicator-agent-activation`
+
+---
+
+## 背景与目标
+
+issue #33 打通了「添加」：agent 经 `indicator_author` 创作自定义指标并上榜 GUI 选择器。但「使用」断在最后一公里——激活名册（chart-state / `dshtrading.chart.v1`）只在浏览器 localStorage，host 平面不可达：agent 无法把指标挂上用户图表，也无法枚举指标库（只能猜 id）。本变更把激活名册升位为 host SSOT 并开放 agent 工具面，补齐「右侧 agent 直接添加**和使用**自定义指标」的完整链路。
+
+## 核心架构与设计决策
+
+### 1. 复用两个既有定稿模式（不发明新机制）
+
+- **host SSOT + 客户端镜像**（issue #32 watchlist 先例）：激活名册落 `~/.dsh/indicators/chart.json`（tmp+rename 原子写），GUI 变更 host-first，localStorage 降级为缓存镜像；桥不可用时本地维持现状（不劣于升级前）。
+- **零 payload 失效信号**（issue #30 定稿）：eventbus 是封闭集合 + revision，不搬运业务负载——「agent 挂指标 → 图表点亮」走 emit('chart') → 客户端 refetch，而非推送命令（推送在浏览器关闭时丢动作，且违反总线零载荷裁决）。
+
+### 2. 分层改动
+
+| 包 | 改动 |
+| --- | --- |
+| `@dshtrading/indicators` | `chart-activations.ts`（纯数据：ChartActivationStore 接口 + 内存版 + resolveIndicatorSpec/clampActivationParams/defaultActivationInstance，浏览器安全）+ `chart-activations-fs.ts`（file 版）+ `chart-tools.ts`（三个工具工厂）；plugin 收口注册并 provide `tradingChartActivations` Service（桥与工具共享单实例） |
+| `@dshtrading/eventbus` | TradingEventStore 加 'chart' 成员（union 注释写明的扩展方式；客户端 api.ts 镜像词汇同步加） |
+| `@dshtrading/client-ui-trading` | 桥 GET/PUT/DELETE `/chart/indicators` + POST `/chart/indicators/import`（host 非空幂等拒绝，watchlist/import 同款）；host 半 store 解析（Service 优先、回退自建）+ 写成功 emit('chart')；client 半 `host-chart-sync.ts`（启动同步 + 一次性迁移 + host-first 写接管 + SSE 重拉） |
+
+### 3. 工具面（host 平面，全会话可见）
+
+- **`indicator_list`**：预置 + 自定义全清单（id/title/pane/参数 schema/描述）+ 当前激活名册（含生效参数）。创作前查重、挂载前选参。
+- **`indicator_activate`**：挂载（可选 paramsJson 覆写，clamp 到 min/max，缺失键取默认）；未知 id 拒绝并列可用集；重复挂载同 id 即调参（每 id 至多一个实例，chart-state 既有语义）。
+- **`indicator_deactivate`**：摘除实例（定义保留；彻底删除走 `indicator_delete`）。
+- **`indicator_author` 加可选 activate 参数**（默认 false）：校验通过落库后按 schema 默认参数直接上图，「一句话创作并上图」一步到位；store 缺席（老部署）降级说明不失败。
+
+### 4. 语义保持与安全边界
+
+- chart-state 创建不 sanitize 的既定裁决不变：host 行客户端照单全收（未知 id 实例 UI 天然不可见，注册表就位后自动生效）；clamp 收敛在写入边界（桥与工具层，host 无注册表实例 → 独立 clamp 实现与 registry 同规则）。
+- 激活名册是纯展示状态（非交易语义），不涉铁律 #3 闸门；桥端点在既有认证栅栏之后。
+- skill 随包分发（铁律 #2）：`indicator-authoring` 指南（indicators SKILL.md + 4 kit 副本）增补「创作即上图」与挂载管理范式。
+
+## 替代方案
+
+- **SSE 推送命令通道**（host 发带 payload 事件、客户端 apply）：落选——eventbus 零载荷裁决 + 浏览器离线丢动作。
+- **仅加 indicator_list**（挂载仍手动）：落选——用户目标即「agent 直接使用」，最后一公里必须打通。
+
+## 验证与验收
+
+1. **全仓门禁**：`pnpm build` 全绿；`pnpm test` 115 文件 903 用例全绿（新增 indicators 12 例：store upsert/坏形拒/replaceAll、clamp/resolve、file store 原子写读回与损坏降级、三工具行为、author activate 路径；新增桥端点 7 例：空册/默认值/clamp/未知 id 业务拒绝/协议 400/removed 语义/迁移幂等/老部署降级）。
+2. **真机端到端**（trading-web profile + 无头 Chrome CDP，host HTTP + 认证栅栏内）：
+   - 启动即迁移：host 空册 → 客户端把 localStorage 默认 MA 名册导入（ROSTER_BEFORE 即含 ma 六周期）；
+   - 页面上下文 `PUT {id:'macd'}` → schema 默认参数落册（fast=12/slow=26/signal=9）→ **SSE 即时点亮 MACD 副图**（截图证据）；
+   - `PUT {id:'rsi', params:{n:999}}` → 桥 clamp 到 n=120 → 图例渲染 RSI(120)；
+   - DELETE removed 语义正确；演示数据已回滚，host 名册回到迁移后的干净态。
+   - 底部快捷词条带 MACD/RSI 同步呈激活态，右侧 agent 面板同框可见。

--- a/packages/base/cordis.patch.yml
+++ b/packages/base/cordis.patch.yml
@@ -59,9 +59,10 @@
     - id: dsh-trading-watchlist
       name: '@dshtrading/watchlist/plugin'
 
-    # 指标能力收口（issue #33 / P4）：provide tradingCustomIndicators 单实例 store 服务
-    # （桥与工具共享缓存），indicator_author/indicator_delete host 平面注册；
-    # 写后 emit tradingEvents('indicators')。
+    # 指标能力收口（issue #33 / P4；issue #63 扩展）：provide tradingCustomIndicators /
+    # tradingChartActivations 单实例 store 服务（桥与工具共享缓存），indicator_author/
+    # indicator_delete 与 indicator_list/indicator_activate/indicator_deactivate host 平面
+    # 注册；写后 emit tradingEvents('indicators'|'chart')。
     - id: dsh-trading-indicators
       name: '@dshtrading/indicators/plugin'
 

--- a/packages/client-ui-trading/src/bridge.ts
+++ b/packages/client-ui-trading/src/bridge.ts
@@ -18,8 +18,8 @@ import { aggregateNews as aggregateCnNews, fetchCnFundamentalsPackage } from '@d
 import { aggregateNews as aggregateHkNews, fetchHkFundamentalsPackage } from '@dshtrading/kit-hk'
 import { aggregateNews as aggregateUsNews, fetchUsFundamentalsPackage } from '@dshtrading/kit-us'
 import { aggregateNews as aggregateCryptoNews, fetchCryptoFundamentalsPackage } from '@dshtrading/kit-crypto'
-import type { CustomIndicatorRecord, CustomIndicatorStore } from '@dshtrading/indicators'
-import { createMemoryCustomIndicatorStore } from '@dshtrading/indicators'
+import type { ChartActivationStore, CustomIndicatorRecord, CustomIndicatorStore, IndicatorInstance } from '@dshtrading/indicators'
+import { clampActivationParams, createMemoryChartActivationStore, createMemoryCustomIndicatorStore, resolveIndicatorSpec } from '@dshtrading/indicators'
 import type { KnowledgeCard, KnowledgeCardStore } from '@dshtrading/knowledge'
 import { createMemoryKnowledgeCardStore } from '@dshtrading/knowledge'
 import type { CustomStrategyRecord, CustomStrategyStore } from '@dshtrading/strategies'
@@ -69,6 +69,8 @@ export function createBridgeHost(services: {
   router?: { activeProvider(market: string): string | undefined } | undefined
   legacy(market: MarketId): MarketDataService | undefined
   customIndicatorsStore?: CustomIndicatorStore | undefined
+  /** 图表激活名册 store（issue #63，可选）。 */
+  chartActivationsStore?: ChartActivationStore | undefined
   knowledgeStore?: KnowledgeCardStore | undefined
   strategyStore?: CustomStrategyStore | undefined
   watchlistStore?: WatchlistStore | undefined
@@ -87,6 +89,7 @@ export function createBridgeHost(services: {
     getTradeService: market => services.tradeRegistry?.active(market)?.service,
     activeProvider: market => services.registry?.active(market)?.provider ?? services.router?.activeProvider(market),
     customIndicatorsStore: services.customIndicatorsStore ?? createMemoryCustomIndicatorStore(),
+    chartActivationsStore: services.chartActivationsStore ?? createMemoryChartActivationStore(),
     knowledgeStore: services.knowledgeStore ?? createMemoryKnowledgeCardStore(),
     strategyStore: services.strategyStore ?? createMemoryCustomStrategyStore(),
     watchlistStore: services.watchlistStore ?? createMemoryWatchlistStore(),
@@ -110,6 +113,8 @@ export interface BridgeHost {
   activeProvider(market: MarketId): string | undefined
   /** 自定义指标存储（可选）。 */
   customIndicatorsStore?: CustomIndicatorStore
+  /** 图表激活名册存储（可选，issue #63）。 */
+  chartActivationsStore?: ChartActivationStore
   /** 知识卡片存储（可选）。 */
   knowledgeStore?: KnowledgeCardStore
   /** 自定义策略存储（可选，issue #31）。 */
@@ -229,6 +234,19 @@ export interface GuiOrderBody {
 export interface CustomIndicatorsWire {
   ok: true
   indicators: CustomIndicatorRecord[]
+}
+
+/** 图表激活名册 wire（issue #63）。 */
+export interface ChartActivationsWire {
+  ok: true
+  instances: IndicatorInstance[]
+}
+
+/** 图表激活写入的业务拒绝（未知指标 id 等；协议错误仍走 BridgeProtocolError）。 */
+export interface ChartActivationRejectedWire {
+  ok: false
+  code: 'TRADING_UNKNOWN_INDICATOR'
+  message: string
 }
 
 export interface KnowledgeCardsWire {
@@ -776,6 +794,71 @@ export class TradingBridge {
     return { ok: true, imported: true }
   }
 
+  /* ---------------------------------------------------------------- */
+  /* 图表激活名册（issue #63）：host store 为 SSOT，localStorage 降级镜像  */
+  /* ---------------------------------------------------------------- */
+
+  /** 全量读取激活名册（GET /chart/indicators）。 */
+  async chartActivations(): Promise<ChartActivationsWire> {
+    const store = this.host.chartActivationsStore
+    if (store === undefined) return { ok: true, instances: [] }
+    return { ok: true, instances: await store.list() }
+  }
+
+  /**
+   * 挂载/更新一个激活实例（PUT /chart/indicators，body { id, params? }）：
+   * id 必须能解析为预置或自定义指标（未知 id 业务拒绝——与 GUI 可渲染集合同源）；
+   * params 按 schema clamp，缺失键取 schema 默认值。
+   */
+  async putChartActivation(body: unknown): Promise<ChartActivationsWire | ChartActivationRejectedWire> {
+    const store = this.host.chartActivationsStore
+    const raw = (body ?? {}) as { id?: unknown; params?: unknown }
+    const id = typeof raw.id === 'string' ? raw.id.trim() : ''
+    if (!id) throw new BridgeProtocolError(400, 'chart activation body requires string id')
+    const spec = await resolveIndicatorSpec(id, this.host.customIndicatorsStore)
+    if (spec === undefined) {
+      return {
+        ok: false,
+        code: 'TRADING_UNKNOWN_INDICATOR',
+        message: 'unknown indicator id ' + JSON.stringify(id) + ' — presets and authored custom ids only (see indicator_list)',
+      }
+    }
+    const overrides: Record<string, number> = {}
+    if (typeof raw.params === 'object' && raw.params !== null && !Array.isArray(raw.params)) {
+      for (const [key, value] of Object.entries(raw.params as Record<string, unknown>)) {
+        if (typeof value === 'number' && Number.isFinite(value)) overrides[key] = value
+      }
+    }
+    const params = clampActivationParams(spec.params, overrides)
+    const instance: IndicatorInstance = { id, params }
+    if (store !== undefined) await store.activate(instance)
+    return { ok: true, instances: store !== undefined ? await store.list() : [instance] }
+  }
+
+  /** 摘除一个激活实例（DELETE /chart/indicators?id=）。 */
+  async removeChartActivation(id: string): Promise<{ ok: boolean; removed: boolean; instances: IndicatorInstance[] }> {
+    const store = this.host.chartActivationsStore
+    if (store === undefined) return { ok: true, removed: false, instances: [] }
+    const removed = await store.deactivate(id)
+    return { ok: true, removed, instances: await store.list() }
+  }
+
+  /**
+   * 一次性迁移导入（POST /chart/indicators/import）：host 非空拒绝（幂等，防重复导入）。
+   * 客户端把 localStorage 存量激活名册搬进 host SSOT（issue #32 watchlist 同款）。
+   */
+  async importChartActivations(body: unknown): Promise<{ ok: boolean; imported: boolean; reason?: string }> {
+    const store = this.host.chartActivationsStore
+    if (store === undefined) return { ok: false, imported: false, reason: 'chart activation store is not mounted' }
+    const existing = await store.list()
+    if (existing.length > 0) {
+      return { ok: false, imported: false, reason: 'host chart activation store is not empty — migration already done (idempotent guard)' }
+    }
+    const instances = parseChartInstances(body)
+    await store.replaceAll(instances)
+    return { ok: true, imported: true }
+  }
+
   /** 读取选中标的（GET /selection）。 */
   async selection(): Promise<{ ok: boolean; instrument: WatchlistInstrument | null }> {
     const store = this.host.selectionStore
@@ -841,6 +924,32 @@ function parseInstrumentBody(body: unknown): WatchlistInstrument {
     symbol,
     ...(typeof raw.name === 'string' && raw.name ? { name: raw.name } : {}),
   }
+}
+
+/**
+ * 激活名册迁移导入的形状校验（{ instances: [...] } 或裸数组）：坏形行丢弃、
+ * params 只收有限数字（host 侧参数 clamp 在 put 语义里，迁移保真原样搬运）。
+ */
+function parseChartInstances(body: unknown): IndicatorInstance[] {
+  const raw = typeof body === 'object' && body !== null && Array.isArray((body as { instances?: unknown }).instances)
+    ? (body as { instances: unknown[] }).instances
+    : Array.isArray(body)
+      ? body
+      : []
+  const out: IndicatorInstance[] = []
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) continue
+    const id = (item as { id?: unknown }).id
+    const params = (item as { params?: unknown }).params
+    if (typeof id !== 'string' || id.trim() === '') continue
+    if (typeof params !== 'object' || params === null) continue
+    const clean: Record<string, number> = {}
+    for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
+      if (typeof value === 'number' && Number.isFinite(value)) clean[key] = value
+    }
+    out.push({ id, params: clean })
+  }
+  return out
 }
 
 /** 请求分发：把 (method, pathname, searchParams) 路由到桥方法，返回 (status, payload)。 */
@@ -912,6 +1021,9 @@ export async function dispatchBridgeRequest(
       case '/indicators/custom': {
         return { status: 200, payload: await bridge.customIndicators() }
       }
+      case '/chart/indicators': {
+        return { status: 200, payload: await bridge.chartActivations() }
+      }
       case '/knowledge/cards': {
         return { status: 200, payload: await bridge.knowledgeCards() }
       }
@@ -939,6 +1051,11 @@ export async function dispatchBridgeRequest(
       const id = search.get('id') ?? ''
       if (!id) throw new BridgeProtocolError(400, 'delete custom indicator: id is required')
       return { status: 200, payload: await bridge.deleteCustomIndicator(id) }
+    }
+    if (pathname === '/chart/indicators') {
+      const id = search.get('id') ?? ''
+      if (!id) throw new BridgeProtocolError(400, 'delete chart activation: id is required')
+      return { status: 200, payload: await bridge.removeChartActivation(id) }
     }
     if (pathname === '/strategies/custom') {
       const id = search.get('id') ?? ''
@@ -969,6 +1086,9 @@ export async function dispatchBridgeRequest(
     if (pathname === '/selection') {
       return { status: 200, payload: await bridge.putSelection(body) }
     }
+    if (pathname === '/chart/indicators') {
+      return { status: 200, payload: await bridge.putChartActivation(body) }
+    }
     throw new BridgeProtocolError(404, `no such endpoint: ${pathname}`)
   }
 
@@ -981,6 +1101,9 @@ export async function dispatchBridgeRequest(
     }
     if (pathname === '/watchlists/import') {
       return { status: 200, payload: await bridge.importWatchlists(body) }
+    }
+    if (pathname === '/chart/indicators/import') {
+      return { status: 200, payload: await bridge.importChartActivations(body) }
     }
     throw new BridgeProtocolError(404, `no such endpoint: ${pathname}`)
   }

--- a/packages/client-ui-trading/src/client/api.ts
+++ b/packages/client-ui-trading/src/client/api.ts
@@ -5,7 +5,7 @@
  */
 import type { AccountBalance, DerivativesData, DerivativesHistory, Kline, MarketId, MarketInfo, Order, Orderbook, Position, TickerOutcome, TradeFill, TradeTick } from './types.ts'
 import type { FundamentalsPackage } from '@dshtrading/api'
-import type { CustomIndicatorRecord } from '@dshtrading/indicators'
+import type { CustomIndicatorRecord, IndicatorInstance } from '@dshtrading/indicators'
 import type { KnowledgeCard } from '@dshtrading/knowledge'
 import type { CustomStrategyRecord } from '@dshtrading/strategies'
 
@@ -432,6 +432,68 @@ export async function putHostSelection(instrument: { market: string; symbol: str
   }
 }
 
+/* ------------------------------------------------------------------ */
+/* 图表激活名册 host SSOT（issue #63）                                      */
+/* ------------------------------------------------------------------ */
+
+/** 全量读取 host 激活名册（GET /chart/indicators）。 */
+export async function fetchChartActivations(): Promise<IndicatorInstance[]> {
+  try {
+    const wire = await getJson<{ ok: boolean; instances: IndicatorInstance[] }>('/dshtrading/api/chart/indicators')
+    return Array.isArray(wire.instances) ? wire.instances : []
+  } catch {
+    return []
+  }
+}
+
+/** 挂载/更新一个激活实例（PUT /chart/indicators；未知 id → ok:false，转 false）。 */
+export async function putChartActivation(id: string, params?: Record<string, number>): Promise<boolean> {
+  try {
+    const response = await fetch('/dshtrading/api/chart/indicators', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id, ...(params !== undefined ? { params } : {}) }),
+    })
+    if (!response.ok) return false
+    const wire = await response.json() as { ok?: boolean }
+    return wire.ok === true
+  } catch {
+    return false
+  }
+}
+
+/** 摘除一个激活实例（DELETE /chart/indicators?id=）。 */
+export async function removeChartActivation(id: string): Promise<boolean> {
+  try {
+    const query = new URLSearchParams({ id })
+    const response = await fetch(`/dshtrading/api/chart/indicators?${query.toString()}`, {
+      method: 'DELETE',
+      headers: { accept: 'application/json' },
+    })
+    if (!response.ok) return false
+    const wire = await response.json() as { ok?: boolean }
+    return wire.ok === true
+  } catch {
+    return false
+  }
+}
+
+/** 一次性迁移导入本地激活名册（POST /chart/indicators/import；host 非空拒绝 → false）。 */
+export async function importChartActivations(instances: IndicatorInstance[]): Promise<boolean> {
+  try {
+    const response = await fetch('/dshtrading/api/chart/indicators/import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ instances }),
+    })
+    if (!response.ok) return false
+    const wire = await response.json() as { ok?: boolean; imported?: boolean }
+    return wire.ok === true && wire.imported === true
+  } catch {
+    return false
+  }
+}
+
 /**
  * store 词汇（v1）：镜像 host 半 @dshtrading/eventbus 的 TradingEventStore.
  * 浏览器半不 import node 包（避免把 cordis 拖进 client bundle）——词汇是封闭
@@ -444,6 +506,7 @@ export type TradingEventStoreName =
   | 'watchlists'
   | 'selection'
   | 'routing'
+  | 'chart'
 
 type TradingEventHandlers = Partial<Record<TradingEventStoreName, () => void>>
 

--- a/packages/client-ui-trading/src/client/host-chart-sync.ts
+++ b/packages/client-ui-trading/src/client/host-chart-sync.ts
@@ -13,7 +13,6 @@
  * 实例对 UI 天然不可见（选择器按 definition 名册渲染），注册表就位后自动生效。
  * host 写入边界的 clamp 已在桥与工具层完成，客户端照单全收。
  */
-import type { IndicatorInstance } from '@dshtrading/indicators'
 import type { ChartStateStore } from './chart-state.ts'
 import { indicators } from './indicator-registry.ts'
 import {

--- a/packages/client-ui-trading/src/client/host-chart-sync.ts
+++ b/packages/client-ui-trading/src/client/host-chart-sync.ts
@@ -1,0 +1,110 @@
+/**
+ * 图表激活名册 host SSOT 同步（issue #63，wireHostWatchlistSync 同款模式）：
+ *
+ * - 启动同步：GET /chart/indicators → host 有行则以 host 为准覆盖本地 observable；
+ *   host 为空且本地 localStorage 有存量 → 一次性迁移导入（POST /chart/indicators/import，
+ *   host 非空时服务端拒绝，幂等）→ 重拉 host。
+ * - 变更 host-first：togglePreset / setParams / removeInstance 先写 host，成功后才
+ *   更新本地 observable（localStorage 由原 store 持久化，降级为缓存镜像）。
+ * - SSE：'chart' 失效信号 → 重拉 host 覆盖本地（indicator_activate/deactivate 工具
+ *   写入、indicators/plugin emit 或其它标签页变更）。
+ *
+ * 语义保持：host 行不过 sanitize（与 chart-state 创建不 sanitize 同裁决）——未知 id
+ * 实例对 UI 天然不可见（选择器按 definition 名册渲染），注册表就位后自动生效。
+ * host 写入边界的 clamp 已在桥与工具层完成，客户端照单全收。
+ */
+import type { IndicatorInstance } from '@dshtrading/indicators'
+import type { ChartStateStore } from './chart-state.ts'
+import { indicators } from './indicator-registry.ts'
+import {
+  fetchChartActivations,
+  importChartActivations,
+  putChartActivation,
+  removeChartActivation,
+  subscribeTradingEvents,
+} from './api.ts'
+
+export interface HostChartSyncOptions {
+  chart: ChartStateStore
+}
+
+/** 启动 host 同步 + 变更接管 + SSE 订阅；返回清理函数（插件卸载语义）。 */
+export function wireHostChartSync(options: HostChartSyncOptions): () => void {
+  const { chart } = options
+
+  const syncFromHost = async (): Promise<void> => {
+    try {
+      const instances = await fetchChartActivations()
+      chart.set({ instances })
+    } catch {
+      /* 桥不可用 → 本地镜像维持现状（不劣于升级前） */
+    }
+  }
+
+  const boot = async (): Promise<void> => {
+    try {
+      const host = await fetchChartActivations()
+      if (host.length > 0) {
+        // host 已有激活行 → host 为准（可能来自工具写入或另一标签页）。
+        chart.set({ instances: host })
+        return
+      }
+      // host 为空 → 一次性迁移本地 localStorage 存量激活名册（幂等，服务端拒绝即跳过）。
+      const local = chart.getSnapshot().instances
+      if (local.length > 0) {
+        const imported = await importChartActivations(local)
+        if (imported) {
+          chart.set({ instances: await fetchChartActivations() })
+        }
+        // 导入被拒（host 非空竞态）→ 拉一次 host 兜底对齐。
+        else {
+          await syncFromHost()
+        }
+      }
+    } catch {
+      /* 迁移/同步失败不阻断启动 */
+    }
+  }
+  void boot()
+
+  // 变更接管：host-first（成功后才更新本地 observable；localStorage 由原方法持久化为镜像）。
+  const originalToggle = chart.togglePreset.bind(chart)
+  chart.togglePreset = (id: string): void => {
+    void (async () => {
+      // 目标状态在本地翻转前判定：未激活 → 挂载（schema 默认参数）；已激活 → 摘除。
+      const willActivate = !chart.isActive(id)
+      const ok = willActivate
+        ? await putChartActivation(id, defaultParamsFor(id))
+        : await removeChartActivation(id)
+      if (ok) originalToggle(id)
+      else console.warn('[dsh-trading] chart toggle failed on host — local state unchanged')
+    })()
+  }
+  const originalSetParams = chart.setParams.bind(chart)
+  chart.setParams = (id: string, params: Record<string, number>): void => {
+    void (async () => {
+      const ok = await putChartActivation(id, params)
+      if (ok) originalSetParams(id, params)
+      else console.warn('[dsh-trading] chart param update failed on host — local state unchanged')
+    })()
+  }
+  const originalRemove = chart.removeInstance.bind(chart)
+  chart.removeInstance = (id: string): void => {
+    void (async () => {
+      const ok = await removeChartActivation(id)
+      if (ok) originalRemove(id)
+      else console.warn('[dsh-trading] chart instance removal failed on host — local state unchanged')
+    })()
+  }
+
+  // SSE 失效信号：工具写入（indicator_activate 等）或其它标签页变更 → 重拉覆盖。
+  return subscribeTradingEvents({
+    chart: () => { void syncFromHost() },
+  })
+}
+
+/** schema 默认参数（与 togglePreset 的 registry.defaultParams 同源；未知 id → 空）。 */
+function defaultParamsFor(id: string): Record<string, number> | undefined {
+  const definition = indicators.get(id)
+  return definition !== undefined ? indicators.defaultParams(definition) : {}
+}

--- a/packages/client-ui-trading/src/client/index.ts
+++ b/packages/client-ui-trading/src/client/index.ts
@@ -33,6 +33,7 @@ import { ChatResizeHandle } from './ChatResizeHandle.tsx'
 import { foldStore, marketFoldStore } from './fold-store.ts'
 import { deleteCustomIndicator, fetchCustomIndicators, subscribeTradingEvents } from './api.ts'
 import { wireHostWatchlistSync } from './host-watchlist-sync.ts'
+import { wireHostChartSync } from './host-chart-sync.ts'
 import './tokens.css'
 import './shell-pad.css'
 import { en, zh } from './locales.ts'
@@ -169,6 +170,11 @@ export function apply(ctx: ClientContext): void {
   // 自选股 host SSOT 同步（issue #32）：启动同步 + 一次性迁移 + 变更 host-first
   // 接管（add/remove/select 写 host 成功后才更新本地）+ SSE 双通道刷新。
   wireHostWatchlistSync({ watchlists, selection })
+
+  // 图表激活名册 host SSOT 同步（issue #63）：agent 经 indicator_activate/
+  // deactivate 写 host → SSE 'chart' → 图表即时点亮；GUI 挂载/摘除/调参同样
+  // host-first（桥不可用时本地镜像维持现状，不劣于升级前）。
+  wireHostChartSync({ chart })
 
   // 左侧停靠：自选面板（官方浮层通道；支持展开与折叠态 MarketRail）。
   ctx.slots.inject('shell.overlay', () => ctx.slots.register({

--- a/packages/client-ui-trading/src/index.ts
+++ b/packages/client-ui-trading/src/index.ts
@@ -14,7 +14,7 @@
 import type { Context } from '@deepseek-ai/cordis'
 import type { MarketDataService } from '@dshtrading/api'
 import type { TradingEventsService } from '@dshtrading/eventbus'
-import { createFileCustomIndicatorStore } from '@dshtrading/indicators/plugin'
+import { createFileChartActivationStore, createFileCustomIndicatorStore } from '@dshtrading/indicators/plugin'
 import { createFileKnowledgeCardStore } from '@dshtrading/knowledge/plugin'
 import { createFileCustomStrategyStore } from '@dshtrading/strategies/plugin'
 import { createFileSelectionStore, createFileWatchlistStore } from '@dshtrading/watchlist/plugin'
@@ -71,6 +71,12 @@ export function apply(ctx: Context): void {
     | undefined
   const customIndicatorsStore = customIndicatorsService?.store
     ?? createFileCustomIndicatorStore(path.join(os.homedir(), '.dsh', 'indicators', 'custom.json'))
+  // issue #63：图表激活名册 store 单实例（Service 解包同上；服务缺席 → 回退自建）。
+  const chartActivationsService = serviceGet('tradingChartActivations') as
+    | { store?: import('@dshtrading/indicators').ChartActivationStore }
+    | undefined
+  const chartActivationsStore = chartActivationsService?.store
+    ?? createFileChartActivationStore(path.join(os.homedir(), '.dsh', 'indicators', 'chart.json'))
   const knowledgeService = serviceGet('tradingKnowledgeCards') as
     | { store?: import('@dshtrading/knowledge').KnowledgeCardStore }
     | undefined
@@ -106,6 +112,7 @@ export function apply(ctx: Context): void {
       router: webCtx.get('tradingMarketRouter', false) as { activeProvider(m: string): string | undefined } | undefined,
       legacy: market => webCtx.get(MARKET_SERVICE_KEYS[market]) as MarketDataService | undefined,
       customIndicatorsStore,
+      chartActivationsStore,
       knowledgeStore,
       strategyStore,
       watchlistStore,
@@ -156,6 +163,10 @@ export function apply(ctx: Context): void {
           // 发布点接线（issue #30/#31/#32）：写成功 → 对应 store 失效信号。
           if (status === 200 && (payload as { ok?: unknown } | undefined)?.ok === true) {
             if (req.method === 'DELETE' && sub === '/indicators/custom') eventsOf()?.emit('indicators')
+            // issue #63：GUI 写激活名册成功 → 'chart' 失效信号（工具写入侧在
+            // indicators/plugin emit，本处只接 GUI 桥写入，避免双 emit）。
+            if ((req.method === 'PUT' || req.method === 'DELETE') && sub === '/chart/indicators') eventsOf()?.emit('chart')
+            if (req.method === 'POST' && sub === '/chart/indicators/import') eventsOf()?.emit('chart')
             if (req.method === 'DELETE' && sub === '/strategies/custom') eventsOf()?.emit('strategies')
             if ((req.method === 'PUT' || req.method === 'POST' || req.method === 'DELETE')
               && (sub === '/watchlists' || sub === '/watchlists/import')) eventsOf()?.emit('watchlists')

--- a/packages/client-ui-trading/test/chart-activations.test.ts
+++ b/packages/client-ui-trading/test/chart-activations.test.ts
@@ -1,0 +1,93 @@
+/**
+ * 图表激活名册桥端点（issue #63）：GET / PUT / DELETE /chart/indicators 与
+ * POST /chart/indicators/import。宿主面用假件 + 内存 store（不触网）。
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  createMemoryChartActivationStore,
+  createMemoryCustomIndicatorStore,
+  resolveIndicatorSpec,
+  type IndicatorParamSpec,
+} from '@dshtrading/indicators'
+import { BridgeProtocolError, TradingBridge, createBridgeHost, dispatchBridgeRequest, type BridgeHost } from '../src/bridge.ts'
+
+function fakeHost(overrides: Partial<BridgeHost> = {}): BridgeHost {
+  return {
+    getMarketService: () => undefined,
+    activeProvider: () => undefined,
+    customIndicatorsStore: createMemoryCustomIndicatorStore([{
+      id: 'td9', title: 'TD9', pane: 'main',
+      params: [{ key: 'count', label: '计数', default: 9, min: 5, max: 13 }] as IndicatorParamSpec[],
+      computeSource: '(bars) => []', createdAt: 1,
+    }]),
+    chartActivationsStore: createMemoryChartActivationStore(),
+    ...overrides,
+  }
+}
+
+describe('图表激活名册桥端点（issue #63）', () => {
+  it('GET 空册 → ok + 空数组', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    const wire = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(wire).toEqual({ status: 200, payload: { ok: true, instances: [] } })
+  })
+
+  it('PUT 预置 id：缺 params → schema 默认值；params 越界 → clamp', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    const put = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), { id: 'macd' })
+    const spec = await resolveIndicatorSpec('macd')
+    const defaults = Object.fromEntries((spec?.params ?? []).map(p => [p.key, p.default]))
+    expect(put).toEqual({ status: 200, payload: { ok: true, instances: [{ id: 'macd', params: defaults }] } })
+
+    const clamped = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), { id: 'td9', params: { count: 999 } }) as { payload: { instances: Array<{ id: string; params: Record<string, number> }> } }
+    expect(clamped.payload.instances).toContainEqual({ id: 'td9', params: { count: 13 } })
+  })
+
+  it('PUT 未知 id → 业务拒绝 TRADING_UNKNOWN_INDICATOR（HTTP 200 信封）', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    const wire = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), { id: 'ghost' })
+    expect(wire).toMatchObject({ status: 200, payload: { ok: false, code: 'TRADING_UNKNOWN_INDICATOR' } })
+  })
+
+  it('PUT 缺 id → 协议错误 400', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    await expect(dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), {}))
+      .rejects.toThrow(BridgeProtocolError)
+  })
+
+  it('DELETE 摘除 → removed 语义；GET 回读一致', async () => {
+    const bridge = new TradingBridge(fakeHost({}, ))
+    await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), { id: 'ma' })
+    const del = await dispatchBridgeRequest(bridge, 'DELETE', '/chart/indicators', new URLSearchParams({ id: 'ma' }))
+    expect(del).toMatchObject({ status: 200, payload: { ok: true, removed: true } })
+    const del2 = await dispatchBridgeRequest(bridge, 'DELETE', '/chart/indicators', new URLSearchParams({ id: 'ma' }))
+    expect(del2).toMatchObject({ status: 200, payload: { ok: true, removed: false } })
+    const list = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(list).toEqual({ status: 200, payload: { ok: true, instances: [] } })
+  })
+
+  it('POST import：host 空册导入成功；非空幂等拒绝', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    const first = await dispatchBridgeRequest(bridge, 'POST', '/chart/indicators/import', new URLSearchParams(), {
+      instances: [{ id: 'rsi', params: { n: 14 } }, { id: 'bad', params: { x: Number.NaN } }],
+    })
+    expect(first).toMatchObject({ status: 200, payload: { ok: true, imported: true } })
+    const list = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    // 坏值行（非有限数字 params）被过滤成空 params 保留——空 params 是合法实例
+    // （零参数自定义指标），行级丢弃只针对 id 缺失/params 非对象。
+    expect(list).toEqual({ status: 200, payload: { ok: true, instances: [{ id: 'rsi', params: { n: 14 } }, { id: 'bad', params: {} }] } })
+
+    const second = await dispatchBridgeRequest(bridge, 'POST', '/chart/indicators/import', new URLSearchParams(), {
+      instances: [{ id: 'kdj', params: {} }],
+    })
+    expect(second).toMatchObject({ status: 200, payload: { ok: false, imported: false } })
+  })
+
+  it('桥缺 chartActivationsStore（老部署）→ 端点静默降级不崩', async () => {
+    const bridge = new TradingBridge(fakeHost({ chartActivationsStore: undefined }))
+    const put = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), { id: 'ma' })
+    expect(put).toMatchObject({ status: 200, payload: { ok: true, instances: [{ id: 'ma', params: expect.anything() }] } })
+    const get = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(get).toEqual({ status: 200, payload: { ok: true, instances: [] } })
+  })
+})

--- a/packages/eventbus/src/index.ts
+++ b/packages/eventbus/src/index.ts
@@ -27,6 +27,7 @@ export const name = 'dsh-trading-eventbus'
 /**
  * store 词汇（v1，封闭集合）。新 store = 本 union 加成员 + 客户端 handler 注册，
  * 事件面不开放任意字符串（防注入 & 保持可枚举）。
+ * 'chart'（issue #63）：图表激活名册（挂载/摘除/调参）失效信号。
  */
 export type TradingEventStore =
   | 'indicators'
@@ -35,6 +36,7 @@ export type TradingEventStore =
   | 'watchlists'
   | 'selection'
   | 'routing'
+  | 'chart'
 
 /** 单条失效信号（桥 SSE 帧的 data 载荷形状，也是 subscribe 回调入参）。 */
 export interface TradingEvent {

--- a/packages/indicators/assets/skills/indicator-authoring/SKILL.md
+++ b/packages/indicators/assets/skills/indicator-authoring/SKILL.md
@@ -221,3 +221,15 @@ export interface IndicatorDefinition {
 ```
 
 若工具返回 `Validation failed`，请根据返回的具体报错信息调整代码（如修复长度不对齐、NaN 防护等）后重新尝试，直至落库成功。
+
+### 4.1 创作即上图（可选一步到位）
+
+`indicator_author` 支持可选参数 `activate`（布尔，默认 false）：置 true 时指标通过校验落库后会立即按 schema 默认参数挂上用户当前图表（GUI 经 SSE 即时点亮），无需再调 `indicator_activate`。适合「帮我写个 XXX 并加到图上」这类一句话需求；仅落库不上图的需求保持缺省。
+
+### 4.2 图表挂载管理（indicator_list / indicator_activate / indicator_deactivate）
+
+- `indicator_list`：枚举全部可用指标——预置与自定义（id/title/pane/参数 schema/描述）及当前激活名册（含生效参数）。创作前查重、挂载前选 id 与参数时先调它。
+- `indicator_activate`：把指标挂上用户图表。`id` 必须是预置或已创作落库的自定义指标；可选 `paramsJson`（JSON 对象，如 `{"period":14}`）覆写参数默认值，越界自动收敛到 min/max，缺失键取默认值。重复挂载同 id 即更新参数（每 id 至多一个实例）。
+- `indicator_deactivate`：从图上摘除一个实例（定义仍在指标库）；彻底删除自定义指标定义用 `indicator_delete`。
+
+典型链路：`indicator_list` 查重 → `indicator_author`（或带 `activate: true` 一步上图）→ 需要调参时 `indicator_activate` + `paramsJson` → `indicator_deactivate` 摘除。

--- a/packages/indicators/src/chart-activations-fs.ts
+++ b/packages/indicators/src/chart-activations-fs.ts
@@ -1,0 +1,87 @@
+/**
+ * 文件持久化版图表激活名册存储（Node.js 宿主侧使用，issue #63）。
+ * 与 custom-fs.ts 同款 tmp + rename 原子写入模式与错误日志纪律。
+ */
+import { readFile, writeFile, rename, mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import type { IndicatorInstance } from './types.ts'
+import type { ChartActivationStore } from './chart-activations.ts'
+
+export function createFileChartActivationStore(filePath: string): ChartActivationStore {
+  let cache: Map<string, IndicatorInstance> | null = null
+
+  async function load(): Promise<Map<string, IndicatorInstance>> {
+    if (cache !== null) return cache
+    try {
+      const content = await readFile(filePath, 'utf8')
+      const parsed: unknown = JSON.parse(content)
+      const map = new Map<string, IndicatorInstance>()
+      if (Array.isArray(parsed)) {
+        for (const item of parsed) {
+          if (item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string') {
+            map.set((item as { id: string }).id, item as IndicatorInstance)
+          }
+        }
+      }
+      cache = map
+      return map
+    } catch (err) {
+      if ((err as { code?: string }).code !== 'ENOENT') {
+        console.error(`[dsh-trading/indicators] failed to read chart activations from ${filePath}:`, err)
+      }
+      cache = new Map<string, IndicatorInstance>()
+      return cache
+    }
+  }
+
+  async function flush(map: Map<string, IndicatorInstance>): Promise<void> {
+    const dir = dirname(filePath)
+    const tmpPath = `${filePath}.tmp.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`
+    const data = JSON.stringify([...map.values()], null, 2)
+    try {
+      await mkdir(dir, { recursive: true })
+      await writeFile(tmpPath, data, 'utf8')
+      let lastError: unknown
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          await rename(tmpPath, filePath)
+          return
+        } catch (err) {
+          const code = (err as { code?: string }).code
+          if (code !== 'EPERM' && code !== 'EBUSY') throw err
+          lastError = err
+          await new Promise(resolve => setTimeout(resolve, 25 * (attempt + 1)))
+        }
+      }
+      throw lastError
+    } catch (error) {
+      console.error(`[dsh-trading/indicators] failed to atomic flush chart activations to ${filePath}:`, error)
+      await import('node:fs/promises').then(m => m.unlink(tmpPath)).catch(() => {})
+      throw error
+    }
+  }
+
+  return {
+    async list() {
+      const map = await load()
+      return [...map.values()].map(instance => ({ id: instance.id, params: { ...instance.params } }))
+    },
+    async activate(instance) {
+      const map = await load()
+      map.set(instance.id, { id: instance.id, params: { ...instance.params } })
+      await flush(map)
+    },
+    async deactivate(id) {
+      const map = await load()
+      const existed = map.delete(id)
+      if (existed) await flush(map)
+      return existed
+    },
+    async replaceAll(instances) {
+      const map = new Map<string, IndicatorInstance>()
+      for (const item of instances) map.set(item.id, { id: item.id, params: { ...item.params } })
+      cache = map
+      await flush(map)
+    },
+  }
+}

--- a/packages/indicators/src/chart-activations.ts
+++ b/packages/indicators/src/chart-activations.ts
@@ -1,0 +1,118 @@
+/**
+ * 图表激活名册（issue #63）：当前挂在用户图上的指标实例列表（每 id 至多一个实例）。
+ * 与 custom.ts 同款分层——本模块纯数据 + 内存存储（浏览器安全，零 Node.js 运行时
+ * 依赖），文件持久化版在 chart-activations-fs.ts（Node 宿主侧）。
+ *
+ * SSOT 语义（issue #32 watchlist 先例）：host 侧 store 为权威，客户端 localStorage
+ * 降级为镜像。写入边界（工具 / 桥）负责按 definition clamp 参数，store 本身保持
+ * 「哑存储」：只校验形状，不理解指标语义。
+ */
+import type { IndicatorInstance, IndicatorPane, IndicatorParamSpec } from './types.ts'
+import type { CustomIndicatorStore } from './custom.ts'
+import { presetDefinitions } from './presets.ts'
+
+/** 激活名册存储接口（工具、桥、单测共用）。 */
+export interface ChartActivationStore {
+  /** 全量读取（插入序，即挂载序）。 */
+  list(): Promise<IndicatorInstance[]>
+  /** 挂载/更新：同 id 覆盖参数（upsert），保持每 id 至多一个实例。 */
+  activate(instance: IndicatorInstance): Promise<void>
+  /** 摘除；返回是否确有该实例。 */
+  deactivate(id: string): Promise<boolean>
+  /** 全量替换（一次性迁移导入 / 客户端启动同步用）。 */
+  replaceAll(instances: IndicatorInstance[]): Promise<void>
+}
+
+/** 指标定义的最小解析面（预置或自定义；pane/title 仅供工具输出展示）。 */
+export interface IndicatorSpecLike {
+  id: string
+  title: string
+  pane: IndicatorPane
+  params: readonly IndicatorParamSpec[]
+  /** 自定义指标才有的可选描述。 */
+  description?: string
+}
+
+/** 实例形状防御：id 非空字符串 + params 纯有限数字对象（坏形丢弃，SSOT 不收脏数据）。 */
+function isValidInstance(raw: unknown): raw is IndicatorInstance {
+  if (typeof raw !== 'object' || raw === null) return false
+  const id = (raw as { id?: unknown }).id
+  const params = (raw as { params?: unknown }).params
+  if (typeof id !== 'string' || id.trim() === '') return false
+  if (typeof params !== 'object' || params === null) return false
+  return Object.values(params as Record<string, unknown>).every(v => typeof v === 'number' && Number.isFinite(v))
+}
+
+/** 内存版激活名册存储（纯浏览器与单测用）。 */
+export function createMemoryChartActivationStore(initial: IndicatorInstance[] = []): ChartActivationStore {
+  const map = new Map<string, IndicatorInstance>()
+  for (const item of initial) {
+    if (isValidInstance(item)) map.set(item.id, { id: item.id, params: { ...item.params } })
+  }
+
+  return {
+    list: async () => [...map.values()].map(instance => ({ id: instance.id, params: { ...instance.params } })),
+    activate: async (instance) => {
+      if (!isValidInstance(instance)) {
+        const id = (instance as { id?: unknown } | null | undefined)?.id
+        throw new Error('chart activation: invalid instance shape for id ' + JSON.stringify(id))
+      }
+      map.set(instance.id, { id: instance.id, params: { ...instance.params } })
+    },
+    deactivate: async (id) => map.delete(id),
+    replaceAll: async (instances) => {
+      map.clear()
+      for (const item of instances) {
+        if (isValidInstance(item)) map.set(item.id, { id: item.id, params: { ...item.params } })
+      }
+    },
+  }
+}
+
+/**
+ * 解析指标定义（预置优先，其次自定义 store）：未知 id 返回 undefined。
+ * 工具与桥的写入边界共用，保证「能挂上图的 id」与「GUI 能渲染的 id」同源。
+ */
+export async function resolveIndicatorSpec(id: string, customStore?: CustomIndicatorStore): Promise<IndicatorSpecLike | undefined> {
+  const preset = presetDefinitions().find(d => d.id === id)
+  if (preset !== undefined) {
+    return { id: preset.id, title: preset.title, pane: preset.pane, params: preset.params }
+  }
+  if (customStore !== undefined) {
+    const record = await customStore.get(id)
+    if (record !== undefined) {
+      return { id: record.id, title: record.title, pane: record.pane, params: record.params, description: record.description }
+    }
+  }
+  return undefined
+}
+
+/**
+ * 参数按 schema clamp（与 registry.clampParams 同规则，独立实现供 host 写入
+ * 边界使用——host 平面没有注册表实例）：有限数字 → min/max 收敛 + 取整；缺失/
+ * 非法 → schema 默认值；schema 外的键丢弃。definition 未知时原样透传有限数字
+ * 键（预置/自定义尚未就位的实例仍可落盘，UI 对未知 id 天然不可见）。
+ */
+export function clampActivationParams(specs: readonly IndicatorParamSpec[] | undefined, params: Record<string, number>): Record<string, number> {
+  const out: Record<string, number> = {}
+  if (specs === undefined) {
+    for (const [key, value] of Object.entries(params)) {
+      if (typeof value === 'number' && Number.isFinite(value)) out[key] = value
+    }
+    return out
+  }
+  for (const spec of specs) {
+    const raw = params[spec.key]
+    out[spec.key] = typeof raw === 'number' && Number.isFinite(raw)
+      ? Math.min(spec.max, Math.max(spec.min, Math.round(raw)))
+      : spec.default
+  }
+  return out
+}
+
+/** 按 schema 生成默认参数实例（definition 缺席 → 空 params，UI 不可见兜底）。 */
+export function defaultActivationInstance(spec: IndicatorSpecLike): IndicatorInstance {
+  const params: Record<string, number> = {}
+  for (const p of spec.params) params[p.key] = p.default
+  return { id: spec.id, params }
+ }

--- a/packages/indicators/src/chart-activations.ts
+++ b/packages/indicators/src/chart-activations.ts
@@ -81,7 +81,13 @@ export async function resolveIndicatorSpec(id: string, customStore?: CustomIndic
   if (customStore !== undefined) {
     const record = await customStore.get(id)
     if (record !== undefined) {
-      return { id: record.id, title: record.title, pane: record.pane, params: record.params, description: record.description }
+      return {
+        id: record.id,
+        title: record.title,
+        pane: record.pane,
+        params: record.params,
+        ...(record.description !== undefined ? { description: record.description } : {}),
+      }
     }
   }
   return undefined

--- a/packages/indicators/src/chart-tools.ts
+++ b/packages/indicators/src/chart-tools.ts
@@ -179,6 +179,10 @@ export function createIndicatorDeactivateTool(options: IndicatorDeactivateToolOp
 export interface ChartToolDeps {
   customStore?: CustomIndicatorStore | undefined
   chartStore: ChartActivationStore
+  /** 可选：挂载/调参成功后的回调（plugin 接线 emit('chart')，GUI 实时同步）。 */
+  onWritten?: () => void
+  /** 可选：摘除成功后的回调（plugin 接线 emit('chart')）。 */
+  onDeleted?: () => void
 }
 
 /** 便捷工厂：一次创建三个激活名册工具。 */

--- a/packages/indicators/src/chart-tools.ts
+++ b/packages/indicators/src/chart-tools.ts
@@ -1,0 +1,194 @@
+/**
+ * 图表激活名册的 Agent 工具面（issue #63）：indicator_list / indicator_activate /
+ * indicator_deactivate。与 tool.ts 的 indicator_author 同层（host 平面注册，
+ * 会话隔离铁律不破）；写入成功后经 onWritten/onDeleted 回调接线 tradingEvents
+ * emit('chart')（接线在 plugin.ts）。
+ */
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import type { CustomIndicatorStore } from './custom.ts'
+import type { ChartActivationStore } from './chart-activations.ts'
+import { clampActivationParams, defaultActivationInstance, resolveIndicatorSpec } from './chart-activations.ts'
+import { presetDefinitions } from './presets.ts'
+
+export interface IndicatorListToolOptions {
+  customStore?: CustomIndicatorStore | undefined
+  chartStore?: ChartActivationStore | undefined
+}
+
+/** indicator_list：枚举预置 + 自定义指标全清单与当前激活名册。 */
+export function createIndicatorListTool(options: IndicatorListToolOptions) {
+  const { customStore, chartStore } = options
+  return defineTool({
+    name: 'indicator_list',
+    description:
+      'List all chart indicators available for the trading GUI: preset indicators and user-authored custom indicators, '
+      + 'each with id, title, pane placement (main/sub), parameter schema (key/label/default/min/max), and optional description. '
+      + 'Also reports the currently active chart roster (activated instances with their live parameters). '
+      + 'Use this before indicator_author (duplicate check) or indicator_activate (pick ids and params).',
+    parameters: {},
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    async execute() {
+      const presets = presetDefinitions().map(d => ({
+        id: d.id,
+        title: d.title,
+        pane: d.pane,
+        params: d.params.map(p => ({ key: p.key, label: p.label, default: p.default, min: p.min, max: p.max })),
+      }))
+      const custom = customStore !== undefined
+        ? (await customStore.list()).map(r => ({
+          id: r.id,
+          title: r.title,
+          pane: r.pane,
+          params: r.params.map(p => ({ key: p.key, label: p.label, default: p.default, min: p.min, max: p.max })),
+          description: r.description,
+        }))
+        : []
+      const active = chartStore !== undefined ? await chartStore.list() : []
+      return JSON.stringify({ presets, custom, active })
+    },
+  })
+}
+
+export interface IndicatorActivateToolOptions {
+  customStore?: CustomIndicatorStore | undefined
+  chartStore: ChartActivationStore
+  /** 可选：挂载成功后的回调（plugin 接线 emit('chart')）。 */
+  onWritten?: (id: string) => void
+}
+
+/** indicator_activate：把指标挂上用户图（已激活则更新参数）。 */
+export function createIndicatorActivateTool(options: IndicatorActivateToolOptions) {
+  const { customStore, chartStore, onWritten } = options
+  return defineTool({
+    name: 'indicator_activate',
+    description:
+      'Mount an indicator onto the user\'s open chart (the GUI renders it live over SSE; no reload needed). '
+      + 'The id must be a preset indicator or a custom indicator authored via indicator_author. '
+      + 'Activating an already-active id updates its parameters in place (one instance per id). '
+      + 'Optionally pass paramsJson to override schema defaults; values are clamped to each parameter\'s min/max. '
+      + 'Use indicator_list to discover ids and parameter schemas.',
+    parameters: {
+      id: {
+        type: 'string',
+        required: true,
+        description: 'Indicator id to mount (preset like "ma"/"macd", or custom id authored via indicator_author)',
+      },
+      paramsJson: {
+        type: 'string',
+        description: 'Optional JSON object of parameter overrides, e.g. {"fast":12,"slow":26,"signal":9}. Missing keys use schema defaults.',
+      },
+    },
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    async execute(raw) {
+      const args = (raw ?? {}) as { id?: unknown; paramsJson?: unknown }
+      const id = typeof args.id === 'string' ? args.id.trim() : ''
+      if (!id) {
+        throw new Error('indicator_activate: id is required')
+      }
+      const spec = await resolveIndicatorSpec(id, customStore)
+      if (spec === undefined) {
+        const available = [
+          ...presetDefinitions().map(d => d.id),
+          ...customStore !== undefined ? (await customStore.list()).map(r => r.id) : [],
+        ]
+        throw new Error('indicator_activate: unknown indicator id ' + JSON.stringify(id)
+          + ' — available ids: ' + available.join(', ')
+          + '. Custom ids require authoring via indicator_author first')
+      }
+
+      let overrides: Record<string, number> = {}
+      if (typeof args.paramsJson === 'string' && args.paramsJson.trim()) {
+        try {
+          const parsed: unknown = JSON.parse(args.paramsJson)
+          if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            return '[indicator_activate] paramsJson must be a JSON object of parameter overrides'
+          }
+          for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+            if (typeof value === 'number' && Number.isFinite(value)) overrides[key] = value
+          }
+        } catch {
+          return '[indicator_activate] Validation failed: paramsJson is not valid JSON (' + args.paramsJson + ')'
+        }
+      }
+
+      const params = clampActivationParams(spec.params, overrides)
+      await chartStore.activate({ id, params })
+      onWritten?.(id)
+
+      const paramText = spec.params.map(p => (p.key + '=' + params[p.key])).join(', ')
+      return '[indicator_activate] Mounted "' + spec.title + '" (id: ' + id + ', pane: ' + spec.pane
+        + (paramText ? ', params: ' + paramText : '') + ') on the chart. '
+        + 'The GUI chart renders it live via the SSE invalidation channel.'
+    },
+  })
+}
+
+export interface IndicatorDeactivateToolOptions {
+  chartStore: ChartActivationStore
+  /** 可选：摘除成功后的回调（plugin 接线 emit('chart')）。 */
+  onDeleted?: (id: string, removed: boolean) => void
+}
+
+/** indicator_deactivate：把指标从用户图上摘除（定义保留在指标库）。 */
+export function createIndicatorDeactivateTool(options: IndicatorDeactivateToolOptions) {
+  const { chartStore, onDeleted } = options
+  return defineTool({
+    name: 'indicator_deactivate',
+    description:
+      'Unmount an indicator from the user\'s open chart (roster refreshes live over SSE). '
+      + 'This only removes the active chart instance — the indicator definition stays in the library '
+      + '(use indicator_delete to remove a custom indicator definition entirely). '
+      + 'Use indicator_list to see the currently active roster.',
+    parameters: {
+      id: {
+        type: 'string',
+        required: true,
+        description: 'Indicator id to unmount from the chart',
+      },
+    },
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    async execute(raw) {
+      const args = (raw ?? {}) as { id?: unknown }
+      const id = typeof args.id === 'string' ? args.id.trim() : ''
+      if (!id) {
+        throw new Error('indicator_deactivate: id is required')
+      }
+      const removed = await chartStore.deactivate(id)
+      onDeleted?.(id, removed)
+      return JSON.stringify({
+        ok: true,
+        removed,
+        note: removed
+          ? 'Unmounted "' + id + '" from the chart (definition kept in the library).'
+          : '"' + id + '" has no active chart instance (see indicator_list for the active roster).',
+      })
+    },
+  })
+}
+
+/** 激活工具族的共享依赖面（plugin 与单测注入用）。 */
+export interface ChartToolDeps {
+  customStore?: CustomIndicatorStore | undefined
+  chartStore: ChartActivationStore
+}
+
+/** 便捷工厂：一次创建三个激活名册工具。 */
+export function createChartActivationTools(deps: ChartToolDeps) {
+  return {
+    list: createIndicatorListTool(deps),
+    activate: createIndicatorActivateTool(deps),
+    deactivate: createIndicatorDeactivateTool(deps),
+  }
+}
+
+// defaultActivationInstance 供 author 工具的「创作即上图」路径复用（tool.ts 引）。
+export { defaultActivationInstance }

--- a/packages/indicators/src/index.ts
+++ b/packages/indicators/src/index.ts
@@ -33,3 +33,11 @@ export {
   type CustomIndicatorRecord,
   type CustomIndicatorStore,
 } from './custom.ts'
+export {
+  clampActivationParams,
+  createMemoryChartActivationStore,
+  defaultActivationInstance,
+  resolveIndicatorSpec,
+  type ChartActivationStore,
+  type IndicatorSpecLike,
+} from './chart-activations.ts'

--- a/packages/indicators/src/plugin.ts
+++ b/packages/indicators/src/plugin.ts
@@ -116,8 +116,8 @@ export function registerIndicatorsTools(ctx: Context, deps: IndicatorsPluginDeps
     register(createAuthorIndicatorTool({
       store: deps.store,
       chartStore: deps.chartStore,
-      onWritten: () => events()?.emit('indicators'),
-      onActivated: () => events()?.emit('chart'),
+      onWritten: () => { events()?.emit('indicators') },
+      onActivated: () => { events()?.emit('chart') },
     }))
     register(createIndicatorDeleteTool({
       store: deps.store,
@@ -128,8 +128,8 @@ export function registerIndicatorsTools(ctx: Context, deps: IndicatorsPluginDeps
       const chartTools = createChartActivationTools({
         customStore: deps.store,
         chartStore: deps.chartStore,
-        onWritten: () => events()?.emit('chart'),
-        onDeleted: () => events()?.emit('chart'),
+        onWritten: () => { events()?.emit('chart') },
+        onDeleted: () => { events()?.emit('chart') },
       })
       register(chartTools.list)
       register(chartTools.activate)

--- a/packages/indicators/src/plugin.ts
+++ b/packages/indicators/src/plugin.ts
@@ -40,7 +40,7 @@ export const TRADING_CHART_ACTIVATIONS_KEY = 'tradingChartActivations'
 
 /** tradingEvents 的最小发布面（鸭式；总线缺席时静默降级）。 */
 export interface TradingEventsPublisher {
-  emit(store: 'indicators'): void
+  emit(store: 'indicators' | 'chart'): void
 }
 
 /** 默认存储路径：~/.dsh/indicators/custom.json（与 client-ui-trading 旧路径一致）。 */
@@ -117,6 +117,7 @@ export function registerIndicatorsTools(ctx: Context, deps: IndicatorsPluginDeps
       store: deps.store,
       chartStore: deps.chartStore,
       onWritten: () => events()?.emit('indicators'),
+      onActivated: () => events()?.emit('chart'),
     }))
     register(createIndicatorDeleteTool({
       store: deps.store,
@@ -127,6 +128,8 @@ export function registerIndicatorsTools(ctx: Context, deps: IndicatorsPluginDeps
       const chartTools = createChartActivationTools({
         customStore: deps.store,
         chartStore: deps.chartStore,
+        onWritten: () => events()?.emit('chart'),
+        onDeleted: () => events()?.emit('chart'),
       })
       register(chartTools.list)
       register(chartTools.activate)

--- a/packages/indicators/src/plugin.ts
+++ b/packages/indicators/src/plugin.ts
@@ -3,11 +3,12 @@
  *
  * patch 行：id `dsh-trading-indicators` / name `@dshtrading/indicators/plugin`
  * （base 拥有该共享行）。职责：
- * - provide `tradingCustomIndicators` 服务（file store 单实例：桥 GET/DELETE 与
- *   indicator_author 共享同一缓存，避免双实例 stale-flush 分裂）；
- * - host 平面注册 `indicator_author`（从 kit/client-ui-trading 双注册收口）与
- *   `indicator_delete`（新增——桥 DELETE 能力的工具面）；
- * - 写成功 emit tradingEvents('indicators')（issue #30 通道）。
+ * - provide `tradingCustomIndicators` / `tradingChartActivations` 服务（file store
+ *   单实例：桥与工具共享同一缓存，避免双实例 stale-flush 分裂）；
+ * - host 平面注册 `indicator_author`（从 kit/client-ui-trading 双注册收口）、
+ *   `indicator_delete`（桥 DELETE 能力的工具面）与 `indicator_list` /
+ *   `indicator_activate` / `indicator_deactivate`（issue #63 图表激活名册工具面）；
+ * - 写成功 emit tradingEvents('indicators' | 'chart')（issue #30 通道，issue #63 扩展）。
  */
 import type { Context } from '@deepseek-ai/cordis'
 import { Service } from '@deepseek-ai/cordis'
@@ -16,10 +17,14 @@ import os from 'node:os'
 import path from 'node:path'
 import { createFileCustomIndicatorStore } from './custom-fs.ts'
 import type { CustomIndicatorRecord, CustomIndicatorStore } from './custom.ts'
+import type { ChartActivationStore } from './chart-activations.ts'
+import { createFileChartActivationStore } from './chart-activations-fs.ts'
+import { createChartActivationTools } from './chart-tools.ts'
 import { createAuthorIndicatorTool } from './tool.ts'
 
 // 桥经本子路径取 file store（knowledge/tool 同款再导出先例）。
 export { createFileCustomIndicatorStore }
+export { createFileChartActivationStore }
 
 /** Cordis 插件名 = patch 行 id（TEMPLATES §8）。 */
 export const name = 'dsh-trading-indicators'
@@ -30,6 +35,9 @@ export const inject: string[] = []
 /** SDK 服务键：自定义指标 store 单实例（桥与工具共享）。 */
 export const TRADING_CUSTOM_INDICATORS_KEY = 'tradingCustomIndicators'
 
+/** SDK 服务键：图表激活名册 store 单实例（issue #63，桥与工具共享）。 */
+export const TRADING_CHART_ACTIVATIONS_KEY = 'tradingChartActivations'
+
 /** tradingEvents 的最小发布面（鸭式；总线缺席时静默降级）。 */
 export interface TradingEventsPublisher {
   emit(store: 'indicators'): void
@@ -38,6 +46,11 @@ export interface TradingEventsPublisher {
 /** 默认存储路径：~/.dsh/indicators/custom.json（与 client-ui-trading 旧路径一致）。 */
 export function defaultStorePath(): string {
   return path.join(os.homedir(), '.dsh', 'indicators', 'custom.json')
+}
+
+/** 默认激活名册路径：~/.dsh/indicators/chart.json（issue #63）。 */
+export function defaultChartStorePath(): string {
+  return path.join(os.homedir(), '.dsh', 'indicators', 'chart.json')
 }
 
 export interface IndicatorDeleteToolOptions {
@@ -85,6 +98,8 @@ export function createIndicatorDeleteTool(options: IndicatorDeleteToolOptions) {
 
 export interface IndicatorsPluginDeps {
   store: CustomIndicatorStore
+  /** 可选：图表激活名册 store（issue #63；缺席时激活工具族不注册）。 */
+  chartStore?: ChartActivationStore
 }
 
 export function registerIndicatorsTools(ctx: Context, deps: IndicatorsPluginDeps): void {
@@ -100,27 +115,49 @@ export function registerIndicatorsTools(ctx: Context, deps: IndicatorsPluginDeps
     }
     register(createAuthorIndicatorTool({
       store: deps.store,
+      chartStore: deps.chartStore,
       onWritten: () => events()?.emit('indicators'),
     }))
     register(createIndicatorDeleteTool({
       store: deps.store,
       onDeleted: () => events()?.emit('indicators'),
     }))
+    // 图表激活名册工具族（issue #63）：写成功 emit('chart')，GUI 经 SSE 即时同步。
+    if (deps.chartStore !== undefined) {
+      const chartTools = createChartActivationTools({
+        customStore: deps.store,
+        chartStore: deps.chartStore,
+      })
+      register(chartTools.list)
+      register(chartTools.activate)
+      register(chartTools.deactivate)
+    }
   })
 }
 
 /** Host plugin body：store 服务 provide + 工具注册。 */
 export function apply(ctx: Context): void {
   const store = createFileCustomIndicatorStore(defaultStorePath())
+  const chartStore = createFileChartActivationStore(defaultChartStorePath())
   // Service 单实例：桥（GET/DELETE 端点）与工具共享同一缓存。
   new CustomIndicatorsService(ctx, store)
-  registerIndicatorsTools(ctx, { store })
+  new ChartActivationsService(ctx, chartStore)
+  registerIndicatorsTools(ctx, { store, chartStore })
 }
 
 /** 自定义指标 store 服务（桥与工具的单实例共享点）。 */
 export class CustomIndicatorsService extends Service {
   readonly store: CustomIndicatorStore
   constructor(ctx: Context, store: CustomIndicatorStore, serviceName: string = TRADING_CUSTOM_INDICATORS_KEY) {
+    super(ctx, serviceName)
+    this.store = store
+  }
+}
+
+/** 图表激活名册 store 服务（issue #63，桥与工具的单实例共享点）。 */
+export class ChartActivationsService extends Service {
+  readonly store: ChartActivationStore
+  constructor(ctx: Context, store: ChartActivationStore, serviceName: string = TRADING_CHART_ACTIVATIONS_KEY) {
     super(ctx, serviceName)
     this.store = store
   }

--- a/packages/indicators/src/tool.ts
+++ b/packages/indicators/src/tool.ts
@@ -141,7 +141,7 @@ export interface AuthorIndicatorToolOptions {
   /** 可选：指标成功落盘后的回调（issue #30：事件总线 emit('indicators') 的接线点）。 */
   onWritten?: (record: CustomIndicatorRecord) => void
   /** 可选：图表激活名册 store（issue #63「创作即上图」路径；缺席时 activate 请求降级说明）。 */
-  chartStore?: ChartActivationStore
+  chartStore?: ChartActivationStore | undefined
   /** 可选：创作即上图成功后的回调（plugin 接线 emit('chart')，GUI 实时同步）。 */
   onActivated?: (id: string) => void
 }

--- a/packages/indicators/src/tool.ts
+++ b/packages/indicators/src/tool.ts
@@ -142,10 +142,12 @@ export interface AuthorIndicatorToolOptions {
   onWritten?: (record: CustomIndicatorRecord) => void
   /** 可选：图表激活名册 store（issue #63「创作即上图」路径；缺席时 activate 请求降级说明）。 */
   chartStore?: ChartActivationStore
+  /** 可选：创作即上图成功后的回调（plugin 接线 emit('chart')，GUI 实时同步）。 */
+  onActivated?: (id: string) => void
 }
 
 export function createAuthorIndicatorTool(options: AuthorIndicatorToolOptions) {
-  const { store, onWritten, chartStore } = options
+  const { store, onWritten, chartStore, onActivated } = options
 
   return defineTool({
     name: 'indicator_author',
@@ -251,6 +253,7 @@ export function createAuthorIndicatorTool(options: AuthorIndicatorToolOptions) {
             params: result.record.params,
           })
           await chartStore.activate(instance)
+          onActivated?.(result.record.id)
           activatedNote = ' The indicator has also been mounted on the chart with its default parameters (see indicator_deactivate to unmount).'
         } else {
           activatedNote = ' Note: activate was requested but no chart activation store is available in this deployment — mount it later via indicator_activate.'

--- a/packages/indicators/src/tool.ts
+++ b/packages/indicators/src/tool.ts
@@ -2,6 +2,8 @@ import { defineTool } from '@deepseek-ai/dsh-tools'
 import { presetDefinitions, type IndicatorDefinition } from './presets.ts'
 import type { IndicatorParamSpec, Kline } from './types.ts'
 import type { CustomIndicatorStore } from './custom.ts'
+import type { ChartActivationStore } from './chart-activations.ts'
+import { defaultActivationInstance } from './chart-activations.ts'
 import { validateCustomIndicatorNode } from './validate-node.ts'
 
 export { createFileCustomIndicatorStore } from './custom-fs.ts'
@@ -138,10 +140,12 @@ export interface AuthorIndicatorToolOptions {
   store: CustomIndicatorStore
   /** 可选：指标成功落盘后的回调（issue #30：事件总线 emit('indicators') 的接线点）。 */
   onWritten?: (record: CustomIndicatorRecord) => void
+  /** 可选：图表激活名册 store（issue #63「创作即上图」路径；缺席时 activate 请求降级说明）。 */
+  chartStore?: ChartActivationStore
 }
 
 export function createAuthorIndicatorTool(options: AuthorIndicatorToolOptions) {
-  const { store, onWritten } = options
+  const { store, onWritten, chartStore } = options
 
   return defineTool({
     name: 'indicator_author',
@@ -182,6 +186,13 @@ export function createAuthorIndicatorTool(options: AuthorIndicatorToolOptions) {
         type: 'string',
         description: 'Optional human-readable description or usage guidance for the indicator.',
       },
+      activate: {
+        type: 'boolean',
+        default: false,
+        description:
+          'Optionally mount the indicator onto the user\'s open chart right after successful authoring '
+          + '(issue #63 "author-and-mount" path; default false). Requires the chart activation store to be available.',
+      },
     },
     output: {
       schema: { type: 'string' },
@@ -195,6 +206,7 @@ export function createAuthorIndicatorTool(options: AuthorIndicatorToolOptions) {
         computeSource?: unknown
         paramsJson?: unknown
         description?: unknown
+        activate?: unknown
       }
 
       let parsedParams: IndicatorParamSpec[] = []
@@ -227,10 +239,29 @@ export function createAuthorIndicatorTool(options: AuthorIndicatorToolOptions) {
       await store.save(result.record)
       onWritten?.(result.record)
 
+      // 创作即上图（issue #63）：activate 显式请求且激活名册可用时，按 schema 默认
+      // 参数挂载；store 缺席（老部署/headless）→ 降级说明，不失败（指标已落盘）。
+      let activatedNote = ''
+      if (args.activate === true) {
+        if (chartStore !== undefined) {
+          const instance = defaultActivationInstance({
+            id: result.record.id,
+            title: result.record.title,
+            pane: result.record.pane,
+            params: result.record.params,
+          })
+          await chartStore.activate(instance)
+          activatedNote = ' The indicator has also been mounted on the chart with its default parameters (see indicator_deactivate to unmount).'
+        } else {
+          activatedNote = ' Note: activate was requested but no chart activation store is available in this deployment — mount it later via indicator_activate.'
+        }
+      }
+
       const paramSummary = result.record.params.map(p => `${p.key}=${p.default}`).join(', ')
       return (
         `[indicator_author] Successfully authored indicator "${result.record.title}" (id: ${result.record.id}, pane: ${result.record.pane}${paramSummary ? `, params: ${paramSummary}` : ''}). `
         + 'The indicator has passed 5 sandbox verification scenarios and is now persisted and available in the chart quick indicator bar.'
+        + activatedNote
       )
     },
   })

--- a/packages/indicators/test/chart-activations.test.ts
+++ b/packages/indicators/test/chart-activations.test.ts
@@ -6,7 +6,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterAll, describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it, vi } from 'vitest'
 import {
   clampActivationParams,
   createMemoryChartActivationStore,
@@ -141,6 +141,16 @@ describe('图表激活工具族（indicator_list / activate / deactivate）', ()
     // required 缺失由 dsh-tools 框架校验拦截（execute 内同名校验为防御性冗余）。
     await expect(deactivate.execute({})).rejects.toThrow(/missing required property/)
   })
+
+  it('emit 接线：activate/deactivate 回调经便捷工厂透传（回归：漏接导致 GUI 不实时）', async () => {
+    const onWritten = vi.fn()
+    const onDeleted = vi.fn()
+    const tools = createChartActivationTools({ chartStore: createMemoryChartActivationStore(), onWritten, onDeleted })
+    await tools.activate.execute({ id: 'ma' })
+    expect(onWritten).toHaveBeenCalledTimes(1)
+    await tools.deactivate.execute({ id: 'ma' })
+    expect(onDeleted).toHaveBeenCalledWith('ma', true)
+  })
 })
 
 describe('indicator_author「创作即上图」（issue #63）', () => {
@@ -171,5 +181,18 @@ describe('indicator_author「创作即上图」（issue #63）', () => {
     const out = String(await noChart.execute({ ...AUTHOR_ARGS, activate: true }))
     expect(out).toContain('no chart activation store is available')
     expect(await store.get('authored_i')).toBeDefined()
+  })
+
+  it('onActivated 回调：创作即上图成功后触发（emit 接线点；缺省上图不触发）', async () => {
+    const store = createMemoryCustomIndicatorStore()
+    const chartStore = createMemoryChartActivationStore()
+    const onActivated = vi.fn()
+    await createAuthorIndicatorTool({ store, chartStore, onActivated }).execute({ ...AUTHOR_ARGS, activate: true })
+    expect(onActivated).toHaveBeenCalledTimes(1)
+    expect(onActivated).toHaveBeenCalledWith('authored_i')
+
+    const silent = vi.fn()
+    await createAuthorIndicatorTool({ store, chartStore, onActivated: silent }).execute({ ...AUTHOR_ARGS, id: 'authored_ii' })
+    expect(silent).not.toHaveBeenCalled()
   })
 })

--- a/packages/indicators/test/chart-activations.test.ts
+++ b/packages/indicators/test/chart-activations.test.ts
@@ -1,0 +1,175 @@
+/**
+ * 图表激活名册（issue #63）：内存/文件 store、clamp/resolve 助手、
+ * indicator_list / indicator_activate / indicator_deactivate 工具与
+ * indicator_author 的「创作即上图」路径。
+ */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import {
+  clampActivationParams,
+  createMemoryChartActivationStore,
+  createMemoryCustomIndicatorStore,
+  resolveIndicatorSpec,
+} from '../src/index.js'
+import { createFileChartActivationStore } from '../src/chart-activations-fs.js'
+import { createChartActivationTools } from '../src/chart-tools.js'
+import { createAuthorIndicatorTool } from '../src/tool.js'
+
+const CUSTOM_SOURCE = '(bars) => [{ key: "close_copy", kind: "line", color: "#ff0000", values: bars.map(b => b.close) }]'
+
+const tmpDirs: string[] = []
+afterAll(async () => {
+  for (const dir of tmpDirs) await rm(dir, { recursive: true, force: true })
+})
+
+describe('createMemoryChartActivationStore', () => {
+  it('activate upsert：同 id 覆盖参数，每 id 至多一个实例', async () => {
+    const store = createMemoryChartActivationStore()
+    await store.activate({ id: 'ma', params: { n1: 5 } })
+    await store.activate({ id: 'ma', params: { n1: 10 } })
+    await store.activate({ id: 'macd', params: { fast: 12 } })
+    const list = await store.list()
+    expect(list).toEqual([
+      { id: 'ma', params: { n1: 10 } },
+      { id: 'macd', params: { fast: 12 } },
+    ])
+  })
+
+  it('deactivate 返回是否确有实例；坏形实例被拒', async () => {
+    const store = createMemoryChartActivationStore([{ id: 'rsi', params: { n: 14 } }])
+    expect(await store.deactivate('rsi')).toBe(true)
+    expect(await store.deactivate('rsi')).toBe(false)
+    await expect(store.activate({ id: '', params: {} })).rejects.toThrow(/invalid instance shape/)
+    await expect(store.activate({ id: 'x', params: { a: Number.NaN } })).rejects.toThrow(/invalid instance shape/)
+  })
+
+  it('replaceAll 全量替换（迁移导入路径）', async () => {
+    const store = createMemoryChartActivationStore([{ id: 'ma', params: {} }])
+    await store.replaceAll([{ id: 'kdj', params: { n: 9 } }, { id: 'bad-shape' }])
+    expect(await store.list()).toEqual([{ id: 'kdj', params: { n: 9 } }])
+  })
+})
+
+describe('clampActivationParams / resolveIndicatorSpec', () => {
+  it('clamp：收敛 min/max + 取整，缺失键取默认，schema 外键丢弃', () => {
+    const specs = [
+      { key: 'n', label: 'N', default: 14, min: 2, max: 100 },
+    ]
+    expect(clampActivationParams(specs, { n: 999 })).toEqual({ n: 100 })
+    expect(clampActivationParams(specs, { n: 1.6 })).toEqual({ n: 2 })
+    expect(clampActivationParams(specs, {})).toEqual({ n: 14 })
+    expect(clampActivationParams(specs, { n: 14, ghost: 5 })).toEqual({ n: 14 })
+    expect(clampActivationParams(undefined, { a: 1, bad: Number.NaN })).toEqual({ a: 1 })
+  })
+
+  it('resolveIndicatorSpec：预置优先 → 自定义 store → 未知 undefined', async () => {
+    const custom = createMemoryCustomIndicatorStore([{
+      id: 'td9', title: 'TD9', pane: 'main',
+      params: [{ key: 'count', label: '计数', default: 9, min: 5, max: 13 }],
+      computeSource: CUSTOM_SOURCE, createdAt: 1,
+    }])
+    expect((await resolveIndicatorSpec('ma', custom))?.title).toBe('MA')
+    expect(await resolveIndicatorSpec('td9', custom)).toMatchObject({ title: 'TD9', pane: 'main' })
+    expect(await resolveIndicatorSpec('ghost', custom)).toBeUndefined()
+  })
+})
+
+describe('createFileChartActivationStore', () => {
+  it('原子写读回一致；损坏文件降级空册', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dsh-chart-'))
+    tmpDirs.push(dir)
+    const file = path.join(dir, 'chart.json')
+    const store = createFileChartActivationStore(file)
+    await store.activate({ id: 'ema', params: { n: 20 } })
+    await store.deactivate('ghost')
+    // 新实例从磁盘读回（绕开缓存直接开新 store）
+    const reopened = createFileChartActivationStore(file)
+    expect(await reopened.list()).toEqual([{ id: 'ema', params: { n: 20 } }])
+
+    const corrupt = path.join(dir, 'corrupt.json')
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(corrupt, '{not json', 'utf8')
+    expect(await createFileChartActivationStore(corrupt).list()).toEqual([])
+  })
+})
+
+describe('图表激活工具族（indicator_list / activate / deactivate）', () => {
+  it('indicator_list：预置 + 自定义 + 激活名册一次给全', async () => {
+    const customStore = createMemoryCustomIndicatorStore([{
+      id: 'td9', title: 'TD9', pane: 'main', params: [],
+      computeSource: CUSTOM_SOURCE, createdAt: 1, description: 'Tom DeMark 9',
+    }])
+    const chartStore = createMemoryChartActivationStore([{ id: 'ma', params: { n1: 5 } }])
+    const { list } = createChartActivationTools({ customStore, chartStore })
+    const out = JSON.parse(String(await list.execute({})))
+    expect(out.presets.map((p: { id: string }) => p.id)).toContain('macd')
+    expect(out.custom).toEqual([expect.objectContaining({ id: 'td9', description: 'Tom DeMark 9' })])
+    expect(out.active).toEqual([{ id: 'ma', params: { n1: 5 } }])
+  })
+
+  it('indicator_activate：未知 id 拒绝并列可用集；paramsJson clamp', async () => {
+    const customStore = createMemoryCustomIndicatorStore()
+    const chartStore = createMemoryChartActivationStore()
+    const { activate } = createChartActivationTools({ customStore, chartStore })
+    await expect(activate.execute({ id: 'ghost' })).rejects.toThrow(/available ids/)
+    const out = String(await activate.execute({ id: 'rsi', paramsJson: '{"n":999,"ghost":1}' }))
+    expect(out).toContain('Mounted')
+    expect(await chartStore.list()).toEqual([{ id: 'rsi', params: { n: 120 } }]) // RSI preset max=120
+    expect(String(await activate.execute({ id: 'rsi', paramsJson: 'not-json' }))).toContain('not valid JSON')
+  })
+
+  it('indicator_activate：自定义 id 可挂载；同 id 重复挂载更新参数', async () => {
+    const customStore = createMemoryCustomIndicatorStore([{
+      id: 'td9', title: 'TD9', pane: 'main',
+      params: [{ key: 'count', label: '计数', default: 9, min: 5, max: 13 }],
+      computeSource: CUSTOM_SOURCE, createdAt: 1,
+    }])
+    const chartStore = createMemoryChartActivationStore()
+    const { activate } = createChartActivationTools({ customStore, chartStore })
+    expect(String(await activate.execute({ id: 'td9' }))).toContain('params: count=9')
+    expect(String(await activate.execute({ id: 'td9', paramsJson: '{"count":11}' }))).toContain('count=11')
+    expect(await chartStore.list()).toEqual([{ id: 'td9', params: { count: 11 } }])
+  })
+
+  it('indicator_deactivate：摘除后返回 removed，定义仍在库', async () => {
+    const chartStore = createMemoryChartActivationStore([{ id: 'boll', params: {} }])
+    const { deactivate } = createChartActivationTools({ chartStore })
+    expect(JSON.parse(String(await deactivate.execute({ id: 'boll' })))).toMatchObject({ ok: true, removed: true })
+    expect(JSON.parse(String(await deactivate.execute({ id: 'boll' })))).toMatchObject({ ok: true, removed: false })
+    // required 缺失由 dsh-tools 框架校验拦截（execute 内同名校验为防御性冗余）。
+    await expect(deactivate.execute({})).rejects.toThrow(/missing required property/)
+  })
+})
+
+describe('indicator_author「创作即上图」（issue #63）', () => {
+  const AUTHOR_ARGS = {
+    id: 'authored_i',
+    title: 'Authored',
+    pane: 'sub',
+    computeSource: CUSTOM_SOURCE,
+  }
+
+  it('activate: true → 校验通过后按 schema 默认参数上图', async () => {
+    const store = createMemoryCustomIndicatorStore()
+    const chartStore = createMemoryChartActivationStore()
+    const tool = createAuthorIndicatorTool({ store, chartStore })
+    const out = String(await tool.execute({ ...AUTHOR_ARGS, activate: true }))
+    expect(out).toContain('mounted on the chart')
+    expect(await chartStore.list()).toEqual([{ id: 'authored_i', params: {} }])
+  })
+
+  it('activate 缺省 → 不上图；chartStore 缺席 → 降级说明不失败', async () => {
+    const store = createMemoryCustomIndicatorStore()
+    const chartStore = createMemoryChartActivationStore()
+    const withStore = createAuthorIndicatorTool({ store, chartStore })
+    expect(String(await withStore.execute({ ...AUTHOR_ARGS }))).not.toContain('mounted')
+    expect(await chartStore.list()).toEqual([])
+
+    const noChart = createAuthorIndicatorTool({ store })
+    const out = String(await noChart.execute({ ...AUTHOR_ARGS, activate: true }))
+    expect(out).toContain('no chart activation store is available')
+    expect(await store.get('authored_i')).toBeDefined()
+  })
+})

--- a/packages/kit-cn/assets/skills/indicator-authoring.md
+++ b/packages/kit-cn/assets/skills/indicator-authoring.md
@@ -216,3 +216,15 @@ export interface IndicatorDefinition {
 ```
 
 若工具返回 `Validation failed`，请根据返回的具体报错信息调整代码（如修复长度不对齐、NaN 防护等）后重新尝试，直至落库成功。
+
+### 4.1 创作即上图（可选一步到位）
+
+`indicator_author` 支持可选参数 `activate`（布尔，默认 false）：置 true 时指标通过校验落库后会立即按 schema 默认参数挂上用户当前图表（GUI 经 SSE 即时点亮），无需再调 `indicator_activate`。适合「帮我写个 XXX 并加到图上」这类一句话需求；仅落库不上图的需求保持缺省。
+
+### 4.2 图表挂载管理（indicator_list / indicator_activate / indicator_deactivate）
+
+- `indicator_list`：枚举全部可用指标——预置与自定义（id/title/pane/参数 schema/描述）及当前激活名册（含生效参数）。创作前查重、挂载前选 id 与参数时先调它。
+- `indicator_activate`：把指标挂上用户图表。`id` 必须是预置或已创作落库的自定义指标；可选 `paramsJson`（JSON 对象，如 `{"period":14}`）覆写参数默认值，越界自动收敛到 min/max，缺失键取默认值。重复挂载同 id 即更新参数（每 id 至多一个实例）。
+- `indicator_deactivate`：从图上摘除一个实例（定义仍在指标库）；彻底删除自定义指标定义用 `indicator_delete`。
+
+典型链路：`indicator_list` 查重 → `indicator_author`（或带 `activate: true` 一步上图）→ 需要调参时 `indicator_activate` + `paramsJson` → `indicator_deactivate` 摘除。

--- a/packages/kit-crypto/assets/skills/indicator-authoring.md
+++ b/packages/kit-crypto/assets/skills/indicator-authoring.md
@@ -216,3 +216,15 @@ export interface IndicatorDefinition {
 ```
 
 若工具返回 `Validation failed`，请根据返回的具体报错信息调整代码（如修复长度不对齐、NaN 防护等）后重新尝试，直至落库成功。
+
+### 4.1 创作即上图（可选一步到位）
+
+`indicator_author` 支持可选参数 `activate`（布尔，默认 false）：置 true 时指标通过校验落库后会立即按 schema 默认参数挂上用户当前图表（GUI 经 SSE 即时点亮），无需再调 `indicator_activate`。适合「帮我写个 XXX 并加到图上」这类一句话需求；仅落库不上图的需求保持缺省。
+
+### 4.2 图表挂载管理（indicator_list / indicator_activate / indicator_deactivate）
+
+- `indicator_list`：枚举全部可用指标——预置与自定义（id/title/pane/参数 schema/描述）及当前激活名册（含生效参数）。创作前查重、挂载前选 id 与参数时先调它。
+- `indicator_activate`：把指标挂上用户图表。`id` 必须是预置或已创作落库的自定义指标；可选 `paramsJson`（JSON 对象，如 `{"period":14}`）覆写参数默认值，越界自动收敛到 min/max，缺失键取默认值。重复挂载同 id 即更新参数（每 id 至多一个实例）。
+- `indicator_deactivate`：从图上摘除一个实例（定义仍在指标库）；彻底删除自定义指标定义用 `indicator_delete`。
+
+典型链路：`indicator_list` 查重 → `indicator_author`（或带 `activate: true` 一步上图）→ 需要调参时 `indicator_activate` + `paramsJson` → `indicator_deactivate` 摘除。

--- a/packages/kit-hk/assets/skills/indicator-authoring.md
+++ b/packages/kit-hk/assets/skills/indicator-authoring.md
@@ -216,3 +216,15 @@ export interface IndicatorDefinition {
 ```
 
 若工具返回 `Validation failed`，请根据返回的具体报错信息调整代码（如修复长度不对齐、NaN 防护等）后重新尝试，直至落库成功。
+
+### 4.1 创作即上图（可选一步到位）
+
+`indicator_author` 支持可选参数 `activate`（布尔，默认 false）：置 true 时指标通过校验落库后会立即按 schema 默认参数挂上用户当前图表（GUI 经 SSE 即时点亮），无需再调 `indicator_activate`。适合「帮我写个 XXX 并加到图上」这类一句话需求；仅落库不上图的需求保持缺省。
+
+### 4.2 图表挂载管理（indicator_list / indicator_activate / indicator_deactivate）
+
+- `indicator_list`：枚举全部可用指标——预置与自定义（id/title/pane/参数 schema/描述）及当前激活名册（含生效参数）。创作前查重、挂载前选 id 与参数时先调它。
+- `indicator_activate`：把指标挂上用户图表。`id` 必须是预置或已创作落库的自定义指标；可选 `paramsJson`（JSON 对象，如 `{"period":14}`）覆写参数默认值，越界自动收敛到 min/max，缺失键取默认值。重复挂载同 id 即更新参数（每 id 至多一个实例）。
+- `indicator_deactivate`：从图上摘除一个实例（定义仍在指标库）；彻底删除自定义指标定义用 `indicator_delete`。
+
+典型链路：`indicator_list` 查重 → `indicator_author`（或带 `activate: true` 一步上图）→ 需要调参时 `indicator_activate` + `paramsJson` → `indicator_deactivate` 摘除。

--- a/packages/kit-us/assets/skills/indicator-authoring.md
+++ b/packages/kit-us/assets/skills/indicator-authoring.md
@@ -216,3 +216,15 @@ export interface IndicatorDefinition {
 ```
 
 若工具返回 `Validation failed`，请根据返回的具体报错信息调整代码（如修复长度不对齐、NaN 防护等）后重新尝试，直至落库成功。
+
+### 4.1 创作即上图（可选一步到位）
+
+`indicator_author` 支持可选参数 `activate`（布尔，默认 false）：置 true 时指标通过校验落库后会立即按 schema 默认参数挂上用户当前图表（GUI 经 SSE 即时点亮），无需再调 `indicator_activate`。适合「帮我写个 XXX 并加到图上」这类一句话需求；仅落库不上图的需求保持缺省。
+
+### 4.2 图表挂载管理（indicator_list / indicator_activate / indicator_deactivate）
+
+- `indicator_list`：枚举全部可用指标——预置与自定义（id/title/pane/参数 schema/描述）及当前激活名册（含生效参数）。创作前查重、挂载前选 id 与参数时先调它。
+- `indicator_activate`：把指标挂上用户图表。`id` 必须是预置或已创作落库的自定义指标；可选 `paramsJson`（JSON 对象，如 `{"period":14}`）覆写参数默认值，越界自动收敛到 min/max，缺失键取默认值。重复挂载同 id 即更新参数（每 id 至多一个实例）。
+- `indicator_deactivate`：从图上摘除一个实例（定义仍在指标库）；彻底删除自定义指标定义用 `indicator_delete`。
+
+典型链路：`indicator_list` 查重 → `indicator_author`（或带 `activate: true` 一步上图）→ 需要调参时 `indicator_activate` + `paramsJson` → `indicator_deactivate` 摘除。


### PR DESCRIPTION
Closes #63

## 概要

补齐「右侧 agent 直接添加**和使用**自定义指标」的最后一公里（添加侧 = #33 已交付）。激活名册从浏览器 localStorage 升位为 host SSOT，agent 获得三个新工具 + author 一步上图：

- **indicator_list**：预置 + 自定义全清单（id/title/pane/参数 schema/描述）+ 当前激活名册
- **indicator_activate**：挂载指标（可选 paramsJson 越界 clamp、缺失键取默认；未知 id 拒绝并列可用集；重复挂载即调参）
- **indicator_deactivate**：摘除实例（定义保留）
- **indicator_author 新增可选 activate**（默认 false）：校验落库后按 schema 默认参数直接上图

## 架构（复用既有定稿，不发明新机制）

- **host SSOT + 客户端镜像**（#32 watchlist 先例）：名册落 ~/.dsh/indicators/chart.json（tmp+rename 原子写）；GUI 变更 host-first；桥不可用时本地维持现状
- **零 payload 失效信号**（#30 裁决）：eventbus TradingEventStore 加 'chart'（closed union 设计内扩展）→ 客户端 refetch，不推命令
- **分层**：indicators（store + 工具 + tradingChartActivations Service）/ eventbus（union）/ client-ui-trading（桥 GET/PUT/DELETE /chart/indicators + POST import 幂等迁移 + host-chart-sync 启动同步/host-first/SSE）
- 语义保持：chart-state 创建不 sanitize 不变；clamp 收敛在写入边界；激活名册纯展示状态不涉交易闸门

## 验证

- 全仓 pnpm build 全绿；pnpm test 115 文件 903 用例全绿（新增 19 例：store/clamp/resolve/三工具/author activate 路径 + 桥端点含未知 id 业务拒绝、迁移幂等、老部署降级）
- trading-web profile 真机端到端（无头 Chrome CDP）：启动自动迁移本地名册 → 页面上下文 PUT macd → **SSE 即时点亮 MACD 副图**（截图）→ PUT rsi 越界参数 clamp 到 RSI(120) 图例可见 → DELETE removed 语义正确；演示数据已回滚
- skill 随包分发：indicator-authoring 指南（indicators + 4 kit 副本）增补挂载管理范式

## Notes

- Agent Note: .agents/notes/implemented/feature/2026-09-04-indicator-agent-chart-activation.md