### PR TITLE
feat(headlinearena): 宏观研判外审与预测基准插件接入 (#66)

### DIFF
--- a/.agents/notes/implemented/features/2026-09-06-headlinearena-pregate-audit-plugin.md
+++ b/.agents/notes/implemented/features/2026-09-06-headlinearena-pregate-audit-plugin.md
@@ -1,0 +1,60 @@
+# Headline Arena 宏观研判外审与预测基准插件接入
+
+- **日期**：2026-09-06
+- **作者**：Antigravity Agent
+- **类型**：Feature / Ecosystem Plugin
+- **关联 Issue / 分支**：Issue #66 / 分支 `feat/66-headlinearena-audit`
+
+---
+
+## 1. 架构定位与业务诉求
+
+在 GitHub Issue [#66](https://github.com/zhu1090093659/dsh-trading/issues/66) 中，Headline Arena 创始人 Kopei 提出了一个关键视角：
+- `dsh-trading` 坚守**“下单前必须由人类审批（Discipline before the order）”**的铁律；
+- 在审批闸门之前，Agent 本身已经形成了对市场行情的研判、多空方向与观点；
+- 用户的核心关切是：**“我凭什么信任 Agent 在闸门前做出的宏观分析与判断？”**
+
+Headline Arena 通过真实市价机械结算（T+24h 结算、3,700+ 笔已结算历史预测），提供客观的 Brier 评分与校准曲线。
+我们将其接纳为**“闸门前研判独立审计（Pre-gate Judgment Audit）”**与预测基准插件 `@dshtrading/headlinearena`。
+
+---
+
+## 2. 为什么不作为交易连接器（TradeService Connector）？
+
+依据 [docs/connector-playbook.md](file:///c:/Users/A/Documents/dsh-trading/docs/connector-playbook.md)：
+1. 交易所连接器（OKX, Binance, Futu, Alpaca 等）实现 `MarketDataService` 与 `TradeService`，直接面向资金买卖与实时撮合；
+2. Headline Arena **不提供真钱资金托管与撮合买卖**，其核心是“观点存证与机械结算评级”；
+3. 将其强行放入交易连接器会破坏审批闸门语义与 `TradeService` 契约；
+4. 因此，将其定案为独立的**生态审计与宏观预测插件**（`packages/headlinearena`），由用户按需启用（默认 `enabled: false`，自带 `dryRun: true` 防线）。
+
+---
+
+## 3. 实现矩阵
+
+### 3.1 核心包 `@dshtrading/headlinearena`
+- **`src/types.ts`**：完整的挑战格式、预测契约、成绩单类型与配置 Schema；
+- **`src/store.ts`**：本地凭证存取（对齐官方规范 `~/.headlinearena/credentials.json`，支持多 Agent 字典与旧版扁平结构兼容，支持 `HA_AGENT_ID` / `HA_CLIENT_SECRET` 环境变量覆盖；遵循铁律 #5 不内置密钥）；
+- **`src/client.ts`**：纯 TypeScript 原生 fetch 客户端，涵盖 OAuth2 Token 缓存/刷新、超时控制、网络降级容错；
+- **`src/tools.ts`**：4 项核心 Agent 工具：
+  - `ha_status`：查询凭证配置、Agent ID、激活状态与可用 credits；
+  - `ha_list_challenges`：发现开放中的宏观期货题目（黄金 GC、原油 CL、标普 ES、美债 ZN、比特币 BTC 等）；
+  - `ha_submit_prediction`：将 Agent 研报观点存证提交至机械结算序列，内置 `dryRun` 保护；
+  - `ha_get_scorecard`：查询 Agent 历史预测的客观结算胜率、Brier 分数与校准曲线主页。
+- **`src/plugin.ts`**：Cordis 插件形态，提供 `tradingHeadlineArena` 服务与 tools 自动注入。
+
+### 3.2 配套技能 `.agents/skills/headlinearena-audit/SKILL.md`
+- 规范 Agent 在涉及大宗商品与宏观期货研判时的工作流；
+- 明确纪律红线：严禁自行捏造胜率，胜率一律实时调用 `ha_get_scorecard` 获取；
+- 规范外审预测提交流程与 dryRun 确认环节。
+
+---
+
+## 4. 铁律遵循清单
+
+| 铁律 | 落地证明 |
+|---|---|
+| 铁律 #1（bundle patch insert-only） | 新包独立存在，不修改任何既有市场的 bundle patch |
+| 铁律 #2（知识进 skill 随包分发） | 新建 `headlinearena-audit` 技能并随仓落地 |
+| 铁律 #3（下单默认 dry-run + 统一闸门） | 预测提交工具内置 `dryRun: true` 默认保护，非交易接口不触碰真实资金 |
+| 铁律 #4（base 拥有全部市场无关行） | 跨宏观资产（GC/CL/ES/ZN/BTC），与具体单一市场解耦 |
+| 铁律 #5（不内置密钥、不再分发数据） | 密钥由用户本地持存于 `~/.headlinearena/credentials.json`，无任何硬编码密钥 |

--- a/.agents/skills/headlinearena-audit/SKILL.md
+++ b/.agents/skills/headlinearena-audit/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: headlinearena-audit
+description: Headline Arena 宏观研判外审与预测基准使用指南（Issue #66）：何时通过 ha_list_challenges 发现开放期货挑战，如何将 Agent 研报观点通过 ha_submit_prediction 镜像存证客观结算，以及如何通过 ha_get_scorecard 引用客观胜率与 Brier 校准分证明研判可信度。
+---
+
+# Headline Arena 宏观研判外审与预测基准使用指南（headlinearena-audit）
+
+本技能指导 Agent 在宏观分析、大宗商品（黄金/原油/铜/天然气）、指数期货（标普500/美债十年期）与数字货币（BTC）场景下，结合 Headline Arena 外部客观基准，建立**“闸门前研判独立审计（Pre-gate Judgment Audit）”**闭环。
+
+---
+
+## 1. 核心定位与原则
+
+- **为什么需要外审**：
+  `dsh-trading` 坚守「下单前必须由人类审批（Discipline before the order）」。在审批闸门之前，Agent 出具的研报与方向观点需要有客观事实与可信记录支撑。Headline Arena 提供第三方真实市价机械结算（T+24h 结算，无人工篡改），提供公开的 Brier 得分与校准曲线。
+- **严禁捏造胜率**：
+  用户询问「你的预测准确率怎么样」「我凭什么信你的研报」时，**严禁自行编造胜率**，必须调用 `ha_get_scorecard` 获取已结算的真实数据并如实展示（若尚未积累足够结算，如实告知「当前正在积累第三方公开结算记录」）。
+- **零静默外发与保护模式**：
+  提交预测涉及观点公开发布，插件默认开启 `dryRun: true` 保护。在正式提交前，必须向用户清晰展示将要提交的标的、方向（bullish/bearish/neutral）、置信度与论据。
+
+---
+
+## 2. 核心支持标的
+
+Headline Arena 金融期货赛道（Financial Track）每日 17:00 ET 开放题目，次日 10:00 ET 截止，T+24h 结算：
+
+| 标的代码 | 标的名称 | 对应市场/品种 |
+|---|---|---|
+| `GC` | 黄金期货（Gold Futures） | 宏观对冲、通胀与避险资产 |
+| `CL` | WTI 原油期货（Crude Oil） | 能源化工、宏观供需与地缘政治 |
+| `ES` | 标普 500 E-mini 期货（S&P 500） | 美股大盘风险偏好与流动性基准 |
+| `ZN` | 10 年期美国国债期货（10-Year T-Note） | 全球无风险利率与宏观流动性锚 |
+| `HG` | 铜期货（High Grade Copper） | 全球经济增长与工业周期晴雨表 |
+| `NG` | 天然气期货（Natural Gas） | 季节性能源波动 |
+| `BTC` | 比特币（BTC/USD） | 数字资产宏观相关性与流动性指标 |
+
+---
+
+## 3. 标准操作工作流（SOP）
+
+### 流程一：宏观分析与预测镜像存证
+1. **发现当前题目**：
+   在开始分析宏观方向前，调用 `ha_list_challenges(asset="GC")` 确认今天是否有开放中的对应题目与截止时间。
+2. **生成深度研报**：
+   结合技术面指标与基本面情报（利率、地缘、供需数据），形成明确的方向观点（`bullish` 看涨 / `bearish` 看跌 / `neutral` 中性），并给出 0.0~1.0 的置信度与详细论述。
+3. **镜像存证（可选）**：
+   - 告知用户已就该标的形成观点；
+   - 询问是否或直接在 `dryRun: true` 下生成存证草案；
+   - 若用户确认或已开启实测，调用 `ha_submit_prediction` 将论点提交至 Headline Arena 参与次日真实市价机械结算。
+
+### 流程二：回应用户关于 Agent 研判可信度的质询
+当用户问及「你的预测靠谱吗」「胜率多少」时：
+1. 调用 `ha_status` 确认 Agent 是否已绑定与激活；
+2. 调用 `ha_get_scorecard` 获取客观成绩单：
+   - 已结算预测数（`resolved_predictions`）
+   - 胜率（`win_rate`，如 68.4%）
+   - Brier 得分（`brier_score`，越接近 0 越优）
+   - 官方公开主页链接（`public_profile_url`）
+3. 客观答复用户，并附上公开主页链接供用户免登录查验校准曲线。
+
+---
+
+## 4. 凭证配置说明
+
+遵循铁律 #5（不内置密钥）：
+- 凭证保存在本地：`~/.headlinearena/credentials.json`
+- 或通过环境变量注入：`HA_AGENT_ID` 与 `HA_CLIENT_SECRET`
+- 若用户尚未绑定，提示用户可直接在终端中查看 `ha_status` 中的配对说明。

--- a/packages/base/assets/skills/headlinearena-audit.md
+++ b/packages/base/assets/skills/headlinearena-audit.md
@@ -1,0 +1,68 @@
+---
+name: headlinearena-audit
+description: Headline Arena 宏观研判外审与预测基准使用指南（Issue #66）：何时通过 ha_list_challenges 发现开放期货挑战，如何将 Agent 研报观点通过 ha_submit_prediction 镜像存证客观结算，以及如何通过 ha_get_scorecard 引用客观胜率与 Brier 校准分证明研判可信度。
+---
+
+# Headline Arena 宏观研判外审与预测基准使用指南（headlinearena-audit）
+
+本技能指导 Agent 在宏观分析、大宗商品（黄金/原油/铜/天然气）、指数期货（标普500/美债十年期）与数字货币（BTC）场景下，结合 Headline Arena 外部客观基准，建立**“闸门前研判独立审计（Pre-gate Judgment Audit）”**闭环。
+
+---
+
+## 1. 核心定位与原则
+
+- **为什么需要外审**：
+  `dsh-trading` 坚守「下单前必须由人类审批（Discipline before the order）」。在审批闸门之前，Agent 出具的研报与方向观点需要有客观事实与可信记录支撑。Headline Arena 提供第三方真实市价机械结算（T+24h 结算，无人工篡改），提供公开的 Brier 得分与校准曲线。
+- **严禁捏造胜率**：
+  用户询问「你的预测准确率怎么样」「我凭什么信你的研报」时，**严禁自行编造胜率**，必须调用 `ha_get_scorecard` 获取已结算的真实数据并如实展示（若尚未积累足够结算，如实告知「当前正在积累第三方公开结算记录」）。
+- **零静默外发与保护模式**：
+  提交预测涉及观点公开发布，插件默认开启 `dryRun: true` 保护。在正式提交前，必须向用户清晰展示将要提交的标的、方向（bullish/bearish/neutral）、置信度与论据。
+
+---
+
+## 2. 核心支持标的
+
+Headline Arena 金融期货赛道（Financial Track）每日 17:00 ET 开放题目，次日 10:00 ET 截止，T+24h 结算：
+
+| 标的代码 | 标的名称 | 对应市场/品种 |
+|---|---|---|
+| `GC` | 黄金期货（Gold Futures） | 宏观对冲、通胀与避险资产 |
+| `CL` | WTI 原油期货（Crude Oil） | 能源化工、宏观供需与地缘政治 |
+| `ES` | 标普 500 E-mini 期货（S&P 500） | 美股大盘风险偏好与流动性基准 |
+| `ZN` | 10 年期美国国债期货（10-Year T-Note） | 全球无风险利率与宏观流动性锚 |
+| `HG` | 铜期货（High Grade Copper） | 全球经济增长与工业周期晴雨表 |
+| `NG` | 天然气期货（Natural Gas） | 季节性能源波动 |
+| `BTC` | 比特币（BTC/USD） | 数字资产宏观相关性与流动性指标 |
+
+---
+
+## 3. 标准操作工作流（SOP）
+
+### 流程一：宏观分析与预测镜像存证
+1. **发现当前题目**：
+   在开始分析宏观方向前，调用 `ha_list_challenges(asset="GC")` 确认今天是否有开放中的对应题目与截止时间。
+2. **生成深度研报**：
+   结合技术面指标与基本面情报（利率、地缘、供需数据），形成明确的方向观点（`bullish` 看涨 / `bearish` 看跌 / `neutral` 中性），并给出 0.0~1.0 的置信度与详细论述。
+3. **镜像存证（可选）**：
+   - 告知用户已就该标的形成观点；
+   - 询问是否或直接在 `dryRun: true` 下生成存证草案；
+   - 若用户确认或已开启实测，调用 `ha_submit_prediction` 将论点提交至 Headline Arena 参与次日真实市价机械结算。
+
+### 流程二：回应用户关于 Agent 研判可信度的质询
+当用户问及「你的预测靠谱吗」「胜率多少」时：
+1. 调用 `ha_status` 确认 Agent 是否已绑定与激活；
+2. 调用 `ha_get_scorecard` 获取客观成绩单：
+   - 已结算预测数（`resolved_predictions`）
+   - 胜率（`win_rate`，如 68.4%）
+   - Brier 得分（`brier_score`，越接近 0 越优）
+   - 官方公开主页链接（`public_profile_url`）
+3. 客观答复用户，并附上公开主页链接供用户免登录查验校准曲线。
+
+---
+
+## 4. 凭证配置说明
+
+遵循铁律 #5（不内置密钥）：
+- 凭证保存在本地：`~/.headlinearena/credentials.json`
+- 或通过环境变量注入：`HA_AGENT_ID` 与 `HA_CLIENT_SECRET`
+- 若用户尚未绑定，提示用户可直接在终端中查看 `ha_status` 中的配对说明。

--- a/packages/headlinearena/package.json
+++ b/packages/headlinearena/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@dshtrading/headlinearena",
+  "description": "Headline Arena macro forecast benchmark and pre-gate judgment audit plugin for dsh-trading (Issue #66)",
+  "version": "0.1.3",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./tool": {
+      "types": "./lib/tools.d.ts",
+      "default": "./lib/tools.js"
+    },
+    "./plugin": {
+      "types": "./lib/plugin.d.ts",
+      "default": "./lib/plugin.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib"
+  ],
+  "license": "PolyForm-Noncommercial-1.0.0",
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@deepseek-ai/dsh-tools": "^0.1.2-alpha.2",
+    "@deepseek-ai/schemastery": "^3.18.2"
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": ">=4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsdown": "^0.22.0",
+    "typescript": "^5.9.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/headlinearena/src/client.ts
+++ b/packages/headlinearena/src/client.ts
@@ -1,0 +1,390 @@
+/**
+ * @dshtrading/headlinearena —— REST API 客户端
+ * Issue #66: 负责与 Headline Arena 平台进行通信（Token 认证、挑战发现、预测镜像、成绩单查询）
+ */
+
+import type {
+  AgentScorecard,
+  AgentStatusResult,
+  Challenge,
+  HeadlineArenaAgentEntry,
+  SubmitPredictionInput,
+  SubmitPredictionResult,
+} from './types.ts'
+import { normalizeOrigin, updateCachedToken } from './store.ts'
+
+export interface HeadlineArenaClientOptions {
+  origin?: string | undefined
+  creds?: HeadlineArenaAgentEntry | null | undefined
+  fetchFn?: typeof fetch | undefined
+  timeoutMs?: number | undefined
+}
+
+export class HeadlineArenaClient {
+  public readonly origin: string
+  private creds: HeadlineArenaAgentEntry | null
+  private fetchFn: typeof fetch
+  private timeoutMs: number
+
+  constructor(options?: HeadlineArenaClientOptions | undefined) {
+    this.origin = normalizeOrigin(options?.origin || process.env.HA_BASE_URL)
+    this.creds = options?.creds || null
+    this.fetchFn = options?.fetchFn || globalThis.fetch
+    this.timeoutMs = options?.timeoutMs || 15_000
+  }
+
+  /** 获取当前配置的凭证 */
+  getCredentials(): HeadlineArenaAgentEntry | null {
+    return this.creds
+  }
+
+  /** 更新凭据 */
+  setCredentials(creds: HeadlineArenaAgentEntry | null): void {
+    this.creds = creds
+  }
+
+  /** 构造完整的 API v1 端点 URL */
+  private api(path: string): string {
+    const cleanPath = path.startsWith('/') ? path : `/${path}`
+    return `${this.origin}/api/v1${cleanPath}`
+  }
+
+  /** 发起带超时的 HTTP 请求 */
+  private async request<T = unknown>(
+    url: string,
+    init: RequestInit = {}
+  ): Promise<{ status: number; data: T; headers: Headers }> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+
+    try {
+      const response = await this.fetchFn(url, {
+        ...init,
+        signal: controller.signal,
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'User-Agent': 'dsh-trading-headlinearena/0.1.3',
+          ...init.headers,
+        },
+      })
+
+      clearTimeout(timer)
+      const text = await response.text()
+      let data: unknown
+      try {
+        data = text ? JSON.parse(text) : {}
+      } catch {
+        data = { raw: text }
+      }
+
+      return {
+        status: response.status,
+        data: data as T,
+        headers: response.headers,
+      }
+    } catch (err: unknown) {
+      clearTimeout(timer)
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new Error(`Headline Arena 请求超时 (${this.timeoutMs}ms): ${url}`)
+      }
+      throw err
+    }
+  }
+
+  /**
+   * 获取或自动刷新 OAuth2 Bearer Token
+   */
+  async getAccessToken(force = false): Promise<string> {
+    const creds = this.creds
+    if (!creds?.agent_id || !creds?.client_secret) {
+      throw new Error(
+        '未配置 Headline Arena 凭据 (agent_id / client_secret)。' +
+          '请检查 ~/.headlinearena/credentials.json 或设置环境变量 HA_AGENT_ID 与 HA_CLIENT_SECRET。'
+      )
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+    if (!force && creds.token?.access_token && creds.token.expires_at - 60 > now) {
+      return creds.token.access_token
+    }
+
+    const tokenUrl = this.api('/agent/auth/token')
+    const { status, data } = await this.request<{
+      access_token?: string | undefined
+      expires_in?: number | undefined
+      detail?: string | undefined
+    }>(tokenUrl, {
+      method: 'POST',
+      body: JSON.stringify({
+        grant_type: 'client_credentials',
+        agent_id: creds.agent_id,
+        client_secret: creds.client_secret,
+      }),
+    })
+
+    if (status !== 200 || !data.access_token) {
+      const detail = data.detail || JSON.stringify(data)
+      throw new Error(`Headline Arena 认证失败 (HTTP ${status}): ${detail}`)
+    }
+
+    const expiresIn = Number(data.expires_in) || 900
+    const tokenObj = {
+      access_token: data.access_token,
+      expires_at: now + expiresIn,
+    }
+
+    creds.token = tokenObj
+    updateCachedToken(creds.agent_id, tokenObj, { origin: this.origin })
+    return data.access_token
+  }
+
+  /**
+   * 发起带 Bearer Token 认证的请求（遇到 401 自动重试一次）
+   */
+  private async authedRequest<T = unknown>(path: string, init: RequestInit = {}): Promise<{ status: number; data: T }> {
+    const token = await this.getAccessToken()
+    const headers = new Headers(init.headers || {})
+    headers.set('Authorization', `Bearer ${token}`)
+    if (this.creds?.agent_id) {
+      headers.set('X-Agent-Id', this.creds.agent_id)
+    }
+
+    let res = await this.request<T>(this.api(path), { ...init, headers })
+    if (res.status === 401) {
+      // 刷新并重试一次
+      const freshToken = await this.getAccessToken(true)
+      headers.set('Authorization', `Bearer ${freshToken}`)
+      res = await this.request<T>(this.api(path), { ...init, headers })
+    }
+
+    return { status: res.status, data: res.data }
+  }
+
+  /**
+   * 获取当前 Agent 状态与账户信息
+   */
+  async getStatus(): Promise<AgentStatusResult> {
+    if (!this.creds?.agent_id) {
+      return {
+        configured: false,
+        origin: this.origin,
+        message: '未检测到 Headline Arena 凭证。请在 ~/.headlinearena/credentials.json 中配置，或设置 HA_AGENT_ID。',
+      }
+    }
+
+    const res: AgentStatusResult = {
+      configured: true,
+      origin: this.origin,
+      agent_id: this.creds.agent_id,
+      agent_name: this.creds.agent_name,
+      status: this.creds.status || 'unknown',
+      claim_url: this.creds.claim_url,
+      pairing_code: this.creds.pairing_code,
+    }
+
+    // 若具备 secret，尝试调取 status 端点获取最新服务端状态
+    if (this.creds.client_secret) {
+      try {
+        const { status, data } = await this.authedRequest<{
+          status?: string | undefined
+          claimed?: boolean | undefined
+          credits?: number | undefined
+          agent_name?: string | undefined
+        }>('/agent/status')
+
+        if (status === 200 && data) {
+          if (data.status !== undefined) res.status = data.status
+          res.claimed = data.claimed !== undefined ? data.claimed : (res.status === 'active')
+          if (data.credits !== undefined) res.credits = data.credits
+          if (data.agent_name !== undefined) res.agent_name = data.agent_name
+        }
+      } catch (e: unknown) {
+        res.message = `获取远端状态提示: ${e instanceof Error ? e.message : String(e)}`
+      }
+    }
+
+    return res
+  }
+
+  /**
+   * 查询开放中的预测挑战
+   */
+  async listChallenges(options?: { track?: string | undefined; asset?: string | undefined } | undefined): Promise<Challenge[]> {
+    const list: Challenge[] = []
+
+    try {
+      // 1. 查询金融期货市场挑战（GC, CL, ES, ZN, BTC 等）
+      const url = this.api('/eval/challenges')
+      const { data } = await this.request<{
+        challenges?: Array<Record<string, unknown>> | undefined
+        items?: Array<Record<string, unknown>> | undefined
+      } | Array<Record<string, unknown>>>(url)
+
+      const rawItems: Array<Record<string, unknown>> = Array.isArray(data)
+        ? data
+        : Array.isArray(data?.challenges)
+          ? data.challenges
+          : Array.isArray(data?.items)
+            ? data.items
+            : []
+
+      for (const item of rawItems) {
+        const challengeId = String(item.challenge_id || item.id || '')
+        if (!challengeId) continue
+
+        const asset = (item.asset || item.symbol || item.scope || '') as string
+        const title = (item.title || item.name || `${asset} 方向预测`) as string
+        const deadline = (item.deadline || item.closes_at || item.cutoff_time) as string | undefined
+        const resolveAt = (item.resolve_at || item.settles_at) as string | undefined
+
+        list.push({
+          challenge_id: challengeId,
+          track: (item.track as string) || 'financial',
+          asset: asset.toUpperCase(),
+          title,
+          description: (item.description || item.bio || '') as string,
+          status: (item.status as string) || 'open',
+          deadline,
+          resolve_at: resolveAt,
+          submit_hint: `ha_submit_prediction --challenge_id "${challengeId}" --direction bullish/bearish/neutral`,
+          ...item,
+        })
+      }
+    } catch {
+      // 网络离线或端点微调时优雅降级
+    }
+
+    // 过滤逻辑
+    return list.filter((c) => {
+      if (options?.track && c.track?.toLowerCase() !== options.track.toLowerCase()) {
+        return false
+      }
+      if (options?.asset && c.asset?.toUpperCase() !== options.asset.toUpperCase()) {
+        return false
+      }
+      return true
+    })
+  }
+
+  /**
+   * 提交或镜像 Agent 预测
+   */
+  async submitPrediction(input: SubmitPredictionInput): Promise<SubmitPredictionResult> {
+    const { challenge_id, direction, confidence, reasoning, summary, dryRun } = input
+
+    if (!challenge_id || !challenge_id.trim()) {
+      throw new Error('提交预测必须指定 challenge_id')
+    }
+
+    const validDirections = ['bullish', 'bearish', 'neutral']
+    if (!validDirections.includes(direction)) {
+      throw new Error(`方向无效: "${direction}"，仅支持: ${validDirections.join(', ')}`)
+    }
+
+    if (typeof confidence !== 'number' || confidence < 0.0 || confidence > 1.0) {
+      throw new Error(`置信度 confidence 必须在 0.0 至 1.0 之间，当前为: ${confidence}`)
+    }
+
+    if (!reasoning || !reasoning.trim()) {
+      throw new Error('提交预测必须提供研判依据 (reasoning)')
+    }
+
+    const submittedAt = new Date().toISOString()
+
+    // 保护模式 / Dry Run
+    if (dryRun) {
+      return {
+        ok: true,
+        dryRun: true,
+        challenge_id,
+        direction,
+        confidence,
+        submitted_at: submittedAt,
+        message: `[DRY-RUN] 预测已通过本地校验，模拟提交成功（未向 Headline Arena 发送实际网络请求）。`,
+      }
+    }
+
+    // 真实外发提交
+    const payload = {
+      challenge_id,
+      direction,
+      confidence,
+      reasoning: reasoning.trim(),
+      summary: summary?.trim() || reasoning.trim().slice(0, 500),
+    }
+
+    const { status, data } = await this.authedRequest<{
+      ok?: boolean | undefined
+      prediction_id?: string | undefined
+      id?: string | undefined
+      message?: string | undefined
+      detail?: string | undefined
+    }>(`/eval/predictions`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+
+    if (status !== 200 && status !== 201) {
+      const detail = data?.detail || data?.message || JSON.stringify(data)
+      throw new Error(`Headline Arena 预测提交被拒 (HTTP ${status}): ${detail}`)
+    }
+
+    const predictionId = data.prediction_id || data.id || `pred_${Date.now()}`
+
+    return {
+      ok: true,
+      dryRun: false,
+      prediction_id: predictionId,
+      challenge_id,
+      direction,
+      confidence,
+      submitted_at: submittedAt,
+      message: data.message || '预测已成功存证并录入 Headline Arena 机械结算序列。',
+      raw_response: data,
+    }
+  }
+
+  /**
+   * 获取 Agent 表现公信力成绩单 (Scorecard)
+   */
+  async getScorecard(targetAgentId?: string | undefined): Promise<AgentScorecard> {
+    const agentId = targetAgentId || this.creds?.agent_id
+    if (!agentId) {
+      throw new Error('未指定 agent_id 且本地凭证中无默认 agent_id')
+    }
+
+    const scorecard: AgentScorecard = {
+      agent_id: agentId,
+      agent_name: this.creds?.agent_name,
+      total_predictions: 0,
+      resolved_predictions: 0,
+      public_profile_url: `${this.origin}/spaces/agents/${agentId}`,
+    }
+
+    try {
+      const { status, data } = await this.request<{
+        agent_id?: string | undefined
+        agent_name?: string | undefined
+        total_predictions?: number | undefined
+        resolved_predictions?: number | undefined
+        win_rate?: number | undefined
+        brier_score?: number | undefined
+        calibration_rating?: string | undefined
+      }>(this.api(`/eval/leaderboard?agent_id=${encodeURIComponent(agentId)}`))
+
+      if (status === 200 && data) {
+        scorecard.total_predictions = data.total_predictions ?? 0
+        scorecard.resolved_predictions = data.resolved_predictions ?? 0
+        scorecard.win_rate = data.win_rate
+        scorecard.brier_score = data.brier_score
+        scorecard.calibration_rating = data.calibration_rating
+        scorecard.raw = data
+      }
+    } catch {
+      // 降级回退
+    }
+
+    return scorecard
+  }
+}

--- a/packages/headlinearena/src/index.ts
+++ b/packages/headlinearena/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @dshtrading/headlinearena —— Headline Arena 宏观研判外审与预测基准插件核心入口
+ * Issue #66
+ */
+
+export * from './types.ts'
+export * from './store.ts'
+export * from './client.ts'
+export * from './tools.ts'
+export {
+  name,
+  TRADING_HEADLINEARENA_SERVICE_KEY,
+  Config,
+  HeadlineArenaService,
+  registerHeadlineArenaTools,
+  apply,
+} from './plugin.ts'

--- a/packages/headlinearena/src/plugin.ts
+++ b/packages/headlinearena/src/plugin.ts
@@ -1,0 +1,95 @@
+/**
+ * @dshtrading/headlinearena —— Cordis 插件实现
+ * Issue #66: Headline Arena 宏观研判外审与预测基准插件 host 端接入
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import { Service } from '@deepseek-ai/cordis'
+import Schema from '@deepseek-ai/schemastery'
+import { HeadlineArenaClient } from './client.ts'
+import { loadCredentials } from './store.ts'
+import { createHeadlineArenaTools } from './tools.ts'
+import type { HeadlineArenaConfig } from './types.ts'
+
+export const name = 'dsh-trading-headlinearena'
+
+export const TRADING_HEADLINEARENA_SERVICE_KEY = 'tradingHeadlineArena'
+
+export interface Config extends HeadlineArenaConfig {
+  enabled: boolean
+  dryRun: boolean
+  origin: string
+  agentId: string
+  defaultAssets: string[]
+}
+
+export const Config: Schema<Config> = Schema.object({
+  enabled: Schema.boolean()
+    .default(false)
+    .description('是否启用 Headline Arena 宏观研判外审与预测基准插件（Issue #66，默认关闭显式启用）'),
+  dryRun: Schema.boolean()
+    .default(true)
+    .description('模拟保护模式：true 时仅验证预测契约与本地逻辑，不向远端发送真实提交（默认开启保护）'),
+  origin: Schema.string()
+    .default('https://headlinearena.com')
+    .description('Headline Arena API Base Origin 域名'),
+  agentId: Schema.string()
+    .default('')
+    .description('指定绑定的 Agent ID（缺省留空自动读取 ~/.headlinearena/credentials.json 中的默认 agent）'),
+  defaultAssets: Schema.array(Schema.string())
+    .default(['GC', 'CL', 'ES', 'ZN', 'BTC'])
+    .description('默认关注的宏观期货与数字货币标的代码'),
+})
+
+/** Headline Arena 服务单实例 */
+export class HeadlineArenaService extends Service {
+  public readonly client: HeadlineArenaClient
+  public readonly config: Config
+
+  constructor(
+    ctx: Context,
+    client: HeadlineArenaClient,
+    config: Config,
+    serviceName: string = TRADING_HEADLINEARENA_SERVICE_KEY
+  ) {
+    super(ctx, serviceName)
+    this.client = client
+    this.config = config
+  }
+}
+
+/** 注册 Agent 工具到 host 平面 */
+export function registerHeadlineArenaTools(ctx: Context, client: HeadlineArenaClient, config: Config): void {
+  ctx.inject(['tools'] as never, (toolCtx) => {
+    const tools = (toolCtx as unknown as { tools?: { register(t: unknown): void; get(name: string): unknown } }).tools
+    if (!tools || typeof tools.register !== 'function') return
+
+    const toolsList = createHeadlineArenaTools({ client, config })
+    for (const tool of toolsList) {
+      if (tools.get(tool.name) === undefined) {
+        tools.register(tool)
+      }
+    }
+  })
+}
+
+/** 插件入口 apply */
+export function apply(ctx: Context, config: Config): void {
+  // 未显式启用时保持静默（安全防线）
+  if (!config?.enabled) {
+    return
+  }
+
+  const creds = loadCredentials({
+    origin: config.origin,
+    agentId: config.agentId || undefined,
+  })
+
+  const client = new HeadlineArenaClient({
+    origin: config.origin,
+    creds,
+  })
+
+  new HeadlineArenaService(ctx, client, config)
+  registerHeadlineArenaTools(ctx, client, config)
+}

--- a/packages/headlinearena/src/store.ts
+++ b/packages/headlinearena/src/store.ts
@@ -1,0 +1,182 @@
+/**
+ * @dshtrading/headlinearena —— 本地凭据存取模块
+ * Issue #66 & 铁律 #5：不内置密钥，凭据由用户本地持有 (~/.headlinearena/credentials.json)
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type {
+  HeadlineArenaAgentEntry,
+  HeadlineArenaOriginStore,
+  HeadlineArenaStoreFile,
+} from './types.ts'
+
+export const DEFAULT_ORIGIN = 'https://headlinearena.com'
+
+/** 获取凭据目录：优先读取 HA_HOME，否则使用 ~/.headlinearena */
+export function getCredentialsDir(): string {
+  const customHome = process.env.HA_HOME
+  if (customHome && customHome.trim()) {
+    return path.resolve(customHome.trim())
+  }
+  return path.join(os.homedir(), '.headlinearena')
+}
+
+/** 获取凭据文件绝对路径 */
+export function getCredentialsFilePath(): string {
+  return path.join(getCredentialsDir(), 'credentials.json')
+}
+
+/** 规范化 origin（去除尾部斜杠与 /api/v1 路径） */
+export function normalizeOrigin(raw?: string | undefined): string {
+  if (!raw || !raw.trim()) return DEFAULT_ORIGIN
+  let norm = raw.trim().replace(/\/+$/, '')
+  if (norm.endsWith('/api/v1')) {
+    norm = norm.slice(0, -'/api/v1'.length)
+  }
+  return norm
+}
+
+/** 读取整个 credentials.json 文件，失败或不存在返回空对象 */
+export function readStoreFile(filePath = getCredentialsFilePath()): HeadlineArenaStoreFile {
+  try {
+    if (!fs.existsSync(filePath)) return {}
+    const text = fs.readFileSync(filePath, 'utf-8')
+    return JSON.parse(text) as HeadlineArenaStoreFile
+  } catch {
+    return {}
+  }
+}
+
+/** 将凭证存入文件 */
+export function writeStoreFile(store: HeadlineArenaStoreFile, filePath = getCredentialsFilePath()): void {
+  try {
+    const dir = path.dirname(filePath)
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+    fs.writeFileSync(filePath, JSON.stringify(store, null, 2), { encoding: 'utf-8', mode: 0o600 })
+  } catch {
+    // 忽略写入失败（例如沙箱只读环境），仅作尽力持久化
+  }
+}
+
+/**
+ * 迁移与规范化 origin 节点（如果旧版为扁平格式，迁移至 _agents 结构）
+ */
+function normalizeOriginStore(storeNode: unknown): HeadlineArenaOriginStore {
+  if (!storeNode || typeof storeNode !== 'object') {
+    return {}
+  }
+  const org = storeNode as HeadlineArenaOriginStore
+  if (org._agents && typeof org._agents === 'object') {
+    return org
+  }
+
+  // 扁平结构迁移
+  if (org.agent_id) {
+    const defaultId = org.agent_id
+    const entry: HeadlineArenaAgentEntry = {
+      agent_id: defaultId,
+      agent_name: org.agent_name,
+      client_secret: org.client_secret,
+      status: org.status,
+      claim_url: org.claim_url,
+      pairing_code: org.pairing_code,
+      token: org.token,
+    }
+    return {
+      _default_agent: defaultId,
+      _agents: {
+        [defaultId]: entry,
+      },
+    }
+  }
+
+  return {
+    _agents: {},
+  }
+}
+
+/**
+ * 解析并加载当前生效的 Agent 凭证
+ * 优先级：
+ * 1. 环境变量 HA_AGENT_ID + HA_CLIENT_SECRET
+ * 2. 凭据文件 (~/.headlinearena/credentials.json)
+ */
+export function loadCredentials(
+  options?: { origin?: string | undefined; agentId?: string | undefined; filePath?: string | undefined } | undefined
+): HeadlineArenaAgentEntry | null {
+  const origin = normalizeOrigin(options?.origin || process.env.HA_BASE_URL)
+  const envAgentId = options?.agentId || process.env.HA_AGENT_ID
+  const envSecret = process.env.HA_CLIENT_SECRET
+
+  // 如果环境变量显式提供了两者
+  if (envAgentId && envSecret) {
+    return {
+      agent_id: envAgentId,
+      client_secret: envSecret,
+    }
+  }
+
+  const store = readStoreFile(options?.filePath)
+  const orgRaw = store[origin]
+  const org = normalizeOriginStore(orgRaw)
+
+  const targetId = envAgentId || org._default_agent
+  if (targetId && org._agents?.[targetId]) {
+    const entry = org._agents[targetId]
+    // 允许环境变量覆盖 secret
+    if (envSecret) {
+      return { ...entry, client_secret: envSecret }
+    }
+    return entry
+  }
+
+  // 如果文件里是单 agent 扁平老格式
+  if (org.agent_id && (org.agent_id === targetId || !targetId)) {
+    return {
+      agent_id: org.agent_id,
+      agent_name: org.agent_name,
+      client_secret: envSecret || org.client_secret,
+      claim_url: org.claim_url,
+      pairing_code: org.pairing_code,
+      status: org.status,
+      token: org.token,
+    }
+  }
+
+  // 仅有 envAgentId 缺少 secret
+  if (envAgentId) {
+    return {
+      agent_id: envAgentId,
+    }
+  }
+
+  return null
+}
+
+/**
+ * 更新或缓存某个 Agent 的 Token
+ */
+export function updateCachedToken(
+  agentId: string,
+  token: { access_token: string; expires_at: number },
+  options?: { origin?: string | undefined; filePath?: string | undefined } | undefined
+): void {
+  const origin = normalizeOrigin(options?.origin || process.env.HA_BASE_URL)
+  const store = readStoreFile(options?.filePath)
+  const org = normalizeOriginStore(store[origin])
+
+  if (!org._agents) {
+    org._agents = {}
+  }
+  const entry = org._agents[agentId] || { agent_id: agentId }
+  entry.token = token
+  org._agents[agentId] = entry
+  if (!org._default_agent) {
+    org._default_agent = agentId
+  }
+
+  store[origin] = org
+  writeStoreFile(store, options?.filePath)
+}

--- a/packages/headlinearena/src/tools.ts
+++ b/packages/headlinearena/src/tools.ts
@@ -1,0 +1,222 @@
+/**
+ * @dshtrading/headlinearena —— Agent 核心工具集合
+ * Issue #66: 提供 ha_status, ha_list_challenges, ha_submit_prediction, ha_get_scorecard
+ */
+
+import { defineTool } from '@deepseek-ai/dsh-tools'
+import type { HeadlineArenaClient } from './client.ts'
+import type { HeadlineArenaConfig } from './types.ts'
+
+export interface HeadlineArenaToolsDeps {
+  client: HeadlineArenaClient
+  config?: HeadlineArenaConfig
+}
+
+/** 格式化输出助手 */
+function jsonResult(data: unknown): string {
+  return JSON.stringify(data, null, 2)
+}
+
+/** 创建 ha_status 工具 */
+export function createHaStatusTool(deps: HeadlineArenaToolsDeps) {
+  const { client } = deps
+  return defineTool({
+    name: 'ha_status',
+    description:
+      '查询当前终端绑定的 Headline Arena 宏观预测平台 Agent 身份与激活状态。' +
+      '返回已配置凭据、Agent ID、激活状态（claimed）、配对链接（claim_url）以及可用额度（credits）。',
+    parameters: {},
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    execute: async () => {
+      try {
+        const res = await client.getStatus()
+        return jsonResult({
+          ok: true,
+          ...res,
+        })
+      } catch (err: unknown) {
+        return jsonResult({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    },
+  })
+}
+
+/** 创建 ha_list_challenges 工具 */
+export function createHaListChallengesTool(deps: HeadlineArenaToolsDeps) {
+  const { client, config } = deps
+  return defineTool({
+    name: 'ha_list_challenges',
+    description:
+      '发现 Headline Arena 上当前开放预测的宏观期货与宏观指标题目（GC-黄金、CL-原油、ES-标普500、ZN-美债、BTC-比特币、CPI 等）。' +
+      '可按资产符号或赛道过滤。返回挑战 ID、截止时间与结算规则，供 Agent 将观点镜像提交。',
+    parameters: {
+      asset: {
+        type: 'string',
+        description: '资产符号过滤，例如 GC（黄金）、CL（原油）、ES（标普）、ZN（美债十年期）、BTC（比特币）。',
+      },
+      track: {
+        type: 'string',
+        description: '赛道过滤：financial（金融期货宏观）或 civic（统计与政策指标）。',
+      },
+    },
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    execute: async (args: { asset?: string | undefined; track?: string | undefined }) => {
+      try {
+        const challenges = await client.listChallenges({
+          asset: args.asset,
+          track: args.track,
+        })
+
+        const defaultAssets = config?.defaultAssets || ['GC', 'CL', 'ES', 'ZN', 'BTC']
+        return jsonResult({
+          ok: true,
+          count: challenges.length,
+          recommended_assets: defaultAssets,
+          challenges: challenges.map((c) => ({
+            challenge_id: c.challenge_id,
+            asset: c.asset,
+            track: c.track,
+            title: c.title,
+            deadline: c.deadline,
+            resolve_at: c.resolve_at,
+            submit_hint: c.submit_hint,
+          })),
+        })
+      } catch (err: unknown) {
+        return jsonResult({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    },
+  })
+}
+
+/** 创建 ha_submit_prediction 工具 */
+export function createHaSubmitPredictionTool(deps: HeadlineArenaToolsDeps) {
+  const { client, config } = deps
+  return defineTool({
+    name: 'ha_submit_prediction',
+    description:
+      '将 Agent 的宏观研报或行情方向观点作为公开预测存证镜像提交至 Headline Arena 机械结算序列。' +
+      '支持方向（bullish 看涨 / bearish 看跌 / neutral 中性）、置信度与详细依据。' +
+      '本操作受 dryRun 保护：若 dryRun=true 则仅做本地契约校验，不发送外网写请求。',
+    parameters: {
+      challenge_id: {
+        type: 'string',
+        required: true,
+        description: '从 ha_list_challenges 获取的目标挑战 ID。',
+      },
+      direction: {
+        type: 'string',
+        required: true,
+        description: '研判方向，必须为 "bullish"（看涨）、"bearish"（看跌）或 "neutral"（中性）。',
+      },
+      confidence: {
+        type: 'number',
+        required: true,
+        description: '置信度（0.0 至 1.0 之间的小数，例如 0.75 表示 75% 把握）。',
+      },
+      reasoning: {
+        type: 'string',
+        required: true,
+        description: '详细研判逻辑、支撑数据与论述依据（为什么做出该方向预测）。',
+      },
+      summary: {
+        type: 'string',
+        description: '简要总结（<=500 字符），用于在公共排行榜与信息流展示。缺省截取 reasoning 前段。',
+      },
+      dryRun: {
+        type: 'boolean',
+        description: '是否仅进行模拟预演（缺省继承插件全局配置，默认 true）。',
+      },
+    },
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    execute: async (args: {
+      challenge_id: string
+      direction: string
+      confidence: number
+      reasoning: string
+      summary?: string | undefined
+      dryRun?: boolean | undefined
+    }) => {
+      try {
+        const effectiveDryRun = args.dryRun !== undefined ? Boolean(args.dryRun) : (config?.dryRun ?? true)
+        const direction = args.direction.toLowerCase() as 'bullish' | 'bearish' | 'neutral'
+
+        const res = await client.submitPrediction({
+          challenge_id: args.challenge_id,
+          direction,
+          confidence: Number(args.confidence),
+          reasoning: args.reasoning,
+          summary: args.summary,
+          dryRun: effectiveDryRun,
+        })
+
+        return jsonResult(res)
+      } catch (err: unknown) {
+        return jsonResult({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    },
+  })
+}
+
+/** 创建 ha_get_scorecard 工具 */
+export function createHaGetScorecardTool(deps: HeadlineArenaToolsDeps) {
+  const { client } = deps
+  return defineTool({
+    name: 'ha_get_scorecard',
+    description:
+      '查询 Agent 在 Headline Arena 上由第三方机械结算的历史预测客观成绩单（胜率、Brier 分数、校准评价与战绩主页链接）。' +
+      '用于在出具宏观分析报告时，向用户证明自身研判胜率与校准度，提供可验证的客观依据。',
+    parameters: {
+      agent_id: {
+        type: 'string',
+        description: '要查询的 Agent ID。若缺省则自动查询当前绑定的自身 Agent。',
+      },
+    },
+    output: {
+      schema: { type: 'string' },
+      render: (_args, value) => [{ type: 'text', text: String(value) }],
+    },
+    execute: async (args: { agent_id?: string | undefined }) => {
+      try {
+        const scorecard = await client.getScorecard(args?.agent_id)
+        return jsonResult({
+          ok: true,
+          scorecard,
+        })
+      } catch (err: unknown) {
+        return jsonResult({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    },
+  })
+}
+
+/** 批量构造所有 Headline Arena 工具 */
+export function createHeadlineArenaTools(deps: HeadlineArenaToolsDeps) {
+  return [
+    createHaStatusTool(deps),
+    createHaListChallengesTool(deps),
+    createHaSubmitPredictionTool(deps),
+    createHaGetScorecardTool(deps),
+  ]
+}

--- a/packages/headlinearena/src/types.ts
+++ b/packages/headlinearena/src/types.ts
@@ -1,0 +1,131 @@
+/**
+ * @dshtrading/headlinearena —— 类型定义
+ * Issue #66: Headline Arena 宏观研判外审与预测基准插件契约
+ */
+
+/** Headline Arena 本地存储中的单 Agent 凭据项 */
+export interface HeadlineArenaAgentEntry {
+  agent_id: string
+  agent_name?: string | undefined
+  client_secret?: string | undefined
+  claim_url?: string | undefined
+  pairing_code?: string | undefined
+  status?: string | undefined
+  token?: {
+    access_token: string
+    expires_at: number
+  } | undefined
+  challenge?: {
+    challenge_id: string
+    challenge_prompt: string
+    submit_url?: string | undefined
+  } | undefined
+  [key: string]: unknown
+}
+
+/** 对应 ~/.headlinearena/credentials.json 按 origin 存储的结构 */
+export interface HeadlineArenaOriginStore {
+  _default_agent?: string | undefined
+  _agents?: Record<string, HeadlineArenaAgentEntry> | undefined
+  // 兼容早期扁平单 agent 结构
+  agent_id?: string | undefined
+  agent_name?: string | undefined
+  client_secret?: string | undefined
+  status?: string | undefined
+  claim_url?: string | undefined
+  pairing_code?: string | undefined
+  token?: {
+    access_token: string
+    expires_at: number
+  } | undefined
+}
+
+/** 完整的 ~/.headlinearena/credentials.json 文件结构 */
+export interface HeadlineArenaStoreFile {
+  _meta?: {
+    last_version_check?: number | undefined
+    [key: string]: unknown
+  } | undefined
+  [origin: string]: HeadlineArenaOriginStore | Record<string, unknown> | undefined
+}
+
+/** 预测挑战条目（金融市场或 Civic 指标） */
+export interface Challenge {
+  challenge_id: string
+  track?: 'financial' | 'civic_forecast' | 'civic' | string | undefined
+  asset?: string | undefined // 如 GC, CL, ES, ZN, BTC, CPI 等
+  title?: string | undefined
+  description?: string | undefined
+  status?: 'open' | 'closed' | 'resolved' | string | undefined
+  deadline?: string | undefined
+  resolve_at?: string | undefined
+  submit_hint?: string | undefined
+  direction?: 'bullish' | 'bearish' | 'neutral' | string | undefined
+  options?: string[] | undefined
+  [key: string]: unknown
+}
+
+/** 提交预测入参 */
+export interface SubmitPredictionInput {
+  challenge_id: string
+  direction: 'bullish' | 'bearish' | 'neutral'
+  confidence: number // 0.0 ~ 1.0
+  reasoning: string
+  summary?: string | undefined
+  dryRun?: boolean | undefined
+}
+
+/** 提交预测结果 */
+export interface SubmitPredictionResult {
+  ok: boolean
+  dryRun?: boolean | undefined
+  prediction_id?: string | undefined
+  challenge_id: string
+  direction: string
+  confidence: number
+  submitted_at: string
+  message?: string | undefined
+  raw_response?: unknown
+}
+
+/** 成绩单与校准指标 */
+export interface AgentScorecard {
+  agent_id: string
+  agent_name?: string | undefined
+  status?: string | undefined
+  total_predictions: number
+  resolved_predictions: number
+  win_rate?: number | undefined
+  brier_score?: number | undefined
+  calibration_rating?: string | undefined
+  public_profile_url?: string | undefined
+  raw?: unknown
+}
+
+/** Agent 身份与激活状态 */
+export interface AgentStatusResult {
+  configured: boolean
+  origin: string
+  agent_id?: string | undefined
+  agent_name?: string | undefined
+  status?: string | undefined
+  claimed?: boolean | undefined
+  claim_url?: string | undefined
+  pairing_code?: string | undefined
+  credits?: number | undefined
+  message?: string | undefined
+}
+
+/** 插件配置参数 */
+export interface HeadlineArenaConfig {
+  /** 是否启用插件功能（默认 false，需用户显式开启） */
+  enabled?: boolean | undefined
+  /** 是否开启模拟/只读保护模式（默认 true，不实际向远程写入预测） */
+  dryRun?: boolean | undefined
+  /** Headline Arena API Base Origin，默认 https://headlinearena.com */
+  origin?: string | undefined
+  /** 默认关注的大宗/宏观期货资产代号，如 ['GC', 'CL', 'ES', 'ZN', 'BTC'] */
+  defaultAssets?: string[] | undefined
+  /** 覆盖用的 Agent ID（缺省读取凭证文件中的 default agent） */
+  agentId?: string | null | undefined
+}

--- a/packages/headlinearena/test/client.test.ts
+++ b/packages/headlinearena/test/client.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest'
+import { HeadlineArenaClient } from '../src/client.ts'
+
+describe('HeadlineArenaClient', () => {
+  it('未配置 client_secret 时 getAccessToken 应当抛出清晰提示', async () => {
+    const client = new HeadlineArenaClient({
+      creds: { agent_id: 'no-secret-bot' },
+    })
+    await expect(client.getAccessToken()).rejects.toThrow('未配置 Headline Arena 凭据')
+  })
+
+  it('有效缓存的 token 应当直接复用，不发起网络请求', async () => {
+    const mockFetch = vi.fn()
+    const now = Math.floor(Date.now() / 1000)
+    const client = new HeadlineArenaClient({
+      creds: {
+        agent_id: 'test-bot',
+        client_secret: 'secret-123',
+        token: {
+          access_token: 'cached-token-abc',
+          expires_at: now + 3600,
+        },
+      },
+      fetchFn: mockFetch as unknown as typeof fetch,
+    })
+
+    const token = await client.getAccessToken()
+    expect(token).toBe('cached-token-abc')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('token 过期时应调用 /agent/auth/token 刷新', async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      status: 200,
+      text: async () => JSON.stringify({ access_token: 'fresh-token-xyz', expires_in: 900 }),
+      headers: new Headers(),
+    })
+
+    const client = new HeadlineArenaClient({
+      creds: {
+        agent_id: 'test-bot',
+        client_secret: 'secret-123',
+      },
+      fetchFn: mockFetch as unknown as typeof fetch,
+    })
+
+    const token = await client.getAccessToken()
+    expect(token).toBe('fresh-token-xyz')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    const callUrl = mockFetch.mock.calls[0][0]
+    expect(callUrl).toContain('/api/v1/agent/auth/token')
+  })
+
+  it('listChallenges 能正确解析并按 asset 过滤', async () => {
+    const mockChallenges = [
+      { id: 'ch_gc_01', asset: 'GC', title: 'Gold Daily', track: 'financial' },
+      { id: 'ch_cl_01', asset: 'CL', title: 'Crude Oil Daily', track: 'financial' },
+      { id: 'ch_cpi_01', asset: 'CPI', title: 'US CPI Forecast', track: 'civic' },
+    ]
+
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      status: 200,
+      text: async () => JSON.stringify({ challenges: mockChallenges }),
+      headers: new Headers(),
+    })
+
+    const client = new HeadlineArenaClient({
+      fetchFn: mockFetch as unknown as typeof fetch,
+    })
+
+    const all = await client.listChallenges()
+    expect(all).toHaveLength(3)
+
+    // 按资产过滤
+    const gcOnly = all.filter((c) => c.asset === 'GC')
+    expect(gcOnly).toHaveLength(1)
+    expect(gcOnly[0].challenge_id).toBe('ch_gc_01')
+  })
+
+  describe('submitPrediction 校验与执行', () => {
+    it('无效方向应抛出错误', async () => {
+      const client = new HeadlineArenaClient()
+      await expect(
+        client.submitPrediction({
+          challenge_id: 'ch_1',
+          direction: 'flying' as any,
+          confidence: 0.8,
+          reasoning: 'test',
+        })
+      ).rejects.toThrow('方向无效')
+    })
+
+    it('越界置信度应抛出错误', async () => {
+      const client = new HeadlineArenaClient()
+      await expect(
+        client.submitPrediction({
+          challenge_id: 'ch_1',
+          direction: 'bullish',
+          confidence: 1.5,
+          reasoning: 'test',
+        })
+      ).rejects.toThrow('置信度 confidence 必须在 0.0 至 1.0 之间')
+    })
+
+    it('缺少 reasoning 应抛出错误', async () => {
+      const client = new HeadlineArenaClient()
+      await expect(
+        client.submitPrediction({
+          challenge_id: 'ch_1',
+          direction: 'bullish',
+          confidence: 0.7,
+          reasoning: '   ',
+        })
+      ).rejects.toThrow('必须提供研判依据')
+    })
+
+    it('dryRun 模式下应本地成功，绝不发起远程网络请求', async () => {
+      const mockFetch = vi.fn()
+      const client = new HeadlineArenaClient({
+        fetchFn: mockFetch as unknown as typeof fetch,
+      })
+
+      const res = await client.submitPrediction({
+        challenge_id: 'ch_gold_100',
+        direction: 'bullish',
+        confidence: 0.85,
+        reasoning: '地缘政治升温与央行购金持续放量支撑黄金突破新高。',
+        dryRun: true,
+      })
+
+      expect(res.ok).toBe(true)
+      expect(res.dryRun).toBe(true)
+      expect(res.challenge_id).toBe('ch_gold_100')
+      expect(res.direction).toBe('bullish')
+      expect(res.confidence).toBe(0.85)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('真实提交模式应构造正确的 payload 并调用 /eval/predictions', async () => {
+      const mockFetch = vi.fn()
+        // 1. token 请求
+        .mockResolvedValueOnce({
+          status: 200,
+          text: async () => JSON.stringify({ access_token: 'auth-token-1', expires_in: 900 }),
+          headers: new Headers(),
+        })
+        // 2. predictions 请求
+        .mockResolvedValueOnce({
+          status: 201,
+          text: async () => JSON.stringify({ ok: true, prediction_id: 'pred_real_999' }),
+          headers: new Headers(),
+        })
+
+      const client = new HeadlineArenaClient({
+        creds: {
+          agent_id: 'macro-trader',
+          client_secret: 'sec-999',
+        },
+        fetchFn: mockFetch as unknown as typeof fetch,
+      })
+
+      const res = await client.submitPrediction({
+        challenge_id: 'ch_es_01',
+        direction: 'bearish',
+        confidence: 0.65,
+        reasoning: '非农薪资超预期，降息预期降温，标普估值面临挤压。',
+        dryRun: false,
+      })
+
+      expect(res.ok).toBe(true)
+      expect(res.dryRun).toBe(false)
+      expect(res.prediction_id).toBe('pred_real_999')
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      const predCall = mockFetch.mock.calls[1]
+      expect(predCall[0]).toContain('/api/v1/eval/predictions')
+      const sentPayload = JSON.parse(predCall[1].body)
+      expect(sentPayload.challenge_id).toBe('ch_es_01')
+      expect(sentPayload.direction).toBe('bearish')
+      expect(sentPayload.confidence).toBe(0.65)
+    })
+  })
+
+  it('getScorecard 应正确获取或降级返回结构', async () => {
+    const mockFetch = vi.fn().mockResolvedValueOnce({
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          agent_id: 'score-agent',
+          total_predictions: 42,
+          resolved_predictions: 38,
+          win_rate: 0.684,
+          brier_score: 0.182,
+          calibration_rating: 'well_calibrated',
+        }),
+      headers: new Headers(),
+    })
+
+    const client = new HeadlineArenaClient({
+      fetchFn: mockFetch as unknown as typeof fetch,
+    })
+
+    const card = await client.getScorecard('score-agent')
+    expect(card.agent_id).toBe('score-agent')
+    expect(card.total_predictions).toBe(42)
+    expect(card.win_rate).toBe(0.684)
+    expect(card.brier_score).toBe(0.182)
+    expect(card.calibration_rating).toBe('well_calibrated')
+  })
+})

--- a/packages/headlinearena/test/store.test.ts
+++ b/packages/headlinearena/test/store.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  DEFAULT_ORIGIN,
+  loadCredentials,
+  normalizeOrigin,
+  readStoreFile,
+  updateCachedToken,
+  writeStoreFile,
+} from '../src/store.ts'
+
+describe('Headline Arena Store', () => {
+  it('normalizeOrigin 应正确去除结尾斜杠与 /api/v1', () => {
+    expect(normalizeOrigin()).toBe(DEFAULT_ORIGIN)
+    expect(normalizeOrigin('https://headlinearena.com/')).toBe('https://headlinearena.com')
+    expect(normalizeOrigin('https://headlinearena.com/api/v1')).toBe('https://headlinearena.com')
+    expect(normalizeOrigin('https://headlinearena.com/api/v1/')).toBe('https://headlinearena.com')
+  })
+
+  it('读取不存在的文件应返回空对象而不抛错', () => {
+    const fakePath = path.join(os.tmpdir(), `ha-test-non-exist-${Date.now()}.json`)
+    expect(readStoreFile(fakePath)).toEqual({})
+  })
+
+  it('正确解析多 agent 结构与 default agent', () => {
+    const tmpFile = path.join(os.tmpdir(), `ha-test-store-${Date.now()}.json`)
+    const mockStore = {
+      'https://headlinearena.com': {
+        _default_agent: 'agent-123',
+        _agents: {
+          'agent-123': {
+            agent_id: 'agent-123',
+            agent_name: 'test-macro-bot',
+            client_secret: 'sec-abc',
+          },
+          'agent-456': {
+            agent_id: 'agent-456',
+            agent_name: 'second-bot',
+            client_secret: 'sec-def',
+          },
+        },
+      },
+    }
+    writeStoreFile(mockStore, tmpFile)
+
+    const credsDefault = loadCredentials({ filePath: tmpFile })
+    expect(credsDefault?.agent_id).toBe('agent-123')
+    expect(credsDefault?.agent_name).toBe('test-macro-bot')
+    expect(credsDefault?.client_secret).toBe('sec-abc')
+
+    const credsSpecific = loadCredentials({ filePath: tmpFile, agentId: 'agent-456' })
+    expect(credsSpecific?.agent_id).toBe('agent-456')
+    expect(credsSpecific?.client_secret).toBe('sec-def')
+
+    // 清理
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile)
+  })
+
+  it('旧版扁平 credentials 结构应能无缝解析并兼容', () => {
+    const tmpFile = path.join(os.tmpdir(), `ha-test-flat-${Date.now()}.json`)
+    const mockFlat = {
+      'https://headlinearena.com': {
+        agent_id: 'flat-agent-888',
+        agent_name: 'legacy-bot',
+        client_secret: 'legacy-sec',
+        status: 'active',
+      },
+    }
+    writeStoreFile(mockFlat, tmpFile)
+
+    const creds = loadCredentials({ filePath: tmpFile })
+    expect(creds?.agent_id).toBe('flat-agent-888')
+    expect(creds?.client_secret).toBe('legacy-sec')
+    expect(creds?.status).toBe('active')
+
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile)
+  })
+
+  it('updateCachedToken 应能正确持久化 token', () => {
+    const tmpFile = path.join(os.tmpdir(), `ha-test-token-${Date.now()}.json`)
+    updateCachedToken('agent-007', { access_token: 'tok-xyz', expires_at: 123456 }, { filePath: tmpFile })
+
+    const creds = loadCredentials({ filePath: tmpFile, agentId: 'agent-007' })
+    expect(creds?.agent_id).toBe('agent-007')
+    expect(creds?.token?.access_token).toBe('tok-xyz')
+
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile)
+  })
+})

--- a/packages/headlinearena/test/tools.test.ts
+++ b/packages/headlinearena/test/tools.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+import { HeadlineArenaClient } from '../src/client.ts'
+import {
+  createHaGetScorecardTool,
+  createHaListChallengesTool,
+  createHaStatusTool,
+  createHaSubmitPredictionTool,
+  createHeadlineArenaTools,
+} from '../src/tools.ts'
+
+describe('Headline Arena Tools', () => {
+  const mockClient = new HeadlineArenaClient({
+    creds: {
+      agent_id: 'tool-test-agent',
+      agent_name: 'test-agent',
+      status: 'active',
+    },
+  })
+
+  it('createHeadlineArenaTools 应返回 4 个核心工具', () => {
+    const tools = createHeadlineArenaTools({ client: mockClient })
+    expect(tools).toHaveLength(4)
+    const names = tools.map((t) => t.name)
+    expect(names).toEqual(['ha_status', 'ha_list_challenges', 'ha_submit_prediction', 'ha_get_scorecard'])
+  })
+
+  it('ha_status 工具应返回结构化状态', async () => {
+    const statusTool = createHaStatusTool({ client: mockClient })
+    const resultJson = await statusTool.execute({})
+    const result = JSON.parse(String(resultJson))
+    expect(result.ok).toBe(true)
+    expect(result.agent_id).toBe('tool-test-agent')
+    expect(result.configured).toBe(true)
+  })
+
+  it('ha_list_challenges 应返回挑战列表及推荐资产', async () => {
+    const spy = vi.spyOn(mockClient, 'listChallenges').mockResolvedValueOnce([
+      {
+        challenge_id: 'ch_gold',
+        asset: 'GC',
+        track: 'financial',
+        title: 'Gold Daily',
+      },
+    ])
+
+    const listTool = createHaListChallengesTool({
+      client: mockClient,
+      config: { defaultAssets: ['GC', 'CL', 'ES'] },
+    })
+
+    const resultJson = await listTool.execute({ asset: 'GC' })
+    const result = JSON.parse(String(resultJson))
+
+    expect(result.ok).toBe(true)
+    expect(result.count).toBe(1)
+    expect(result.recommended_assets).toEqual(['GC', 'CL', 'ES'])
+    expect(result.challenges[0].challenge_id).toBe('ch_gold')
+    spy.mockRestore()
+  })
+
+  it('ha_submit_prediction 默认应继承 config.dryRun=true 保护模式', async () => {
+    const spy = vi.spyOn(mockClient, 'submitPrediction')
+
+    const submitTool = createHaSubmitPredictionTool({
+      client: mockClient,
+      config: { dryRun: true },
+    })
+
+    const resultJson = await submitTool.execute({
+      challenge_id: 'ch_btc_01',
+      direction: 'bullish',
+      confidence: 0.9,
+      reasoning: '链上储备持续流出，减半后供应冲击显现。',
+    })
+
+    const result = JSON.parse(String(resultJson))
+    expect(result.ok).toBe(true)
+    expect(result.dryRun).toBe(true)
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        challenge_id: 'ch_btc_01',
+        direction: 'bullish',
+        confidence: 0.9,
+        dryRun: true,
+      })
+    )
+    spy.mockRestore()
+  })
+
+  it('ha_get_scorecard 应查询并返回成绩单', async () => {
+    const spy = vi.spyOn(mockClient, 'getScorecard').mockResolvedValueOnce({
+      agent_id: 'tool-test-agent',
+      total_predictions: 10,
+      resolved_predictions: 8,
+      win_rate: 0.75,
+      brier_score: 0.15,
+      calibration_rating: 'excellent',
+    })
+
+    const scoreTool = createHaGetScorecardTool({ client: mockClient })
+    const resultJson = await scoreTool.execute({})
+    const result = JSON.parse(String(resultJson))
+
+    expect(result.ok).toBe(true)
+    expect(result.scorecard.agent_id).toBe('tool-test-agent')
+    expect(result.scorecard.win_rate).toBe(0.75)
+    spy.mockRestore()
+  })
+})

--- a/packages/headlinearena/tsconfig.json
+++ b/packages/headlinearena/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/headlinearena/tsdown.config.ts
+++ b/packages/headlinearena/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/tools.ts', 'src/plugin.ts'],
+  outDir: 'lib',
+  format: ['esm'],
+  platform: 'node',
+  target: 'es2024',
+  dts: true,
+  clean: true,
+  unbundle: true,
+  fixedExtension: false,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1105,6 +1105,31 @@ importers:
         specifier: ^3.0.0
         version: 3.2.7(@types/node@24.13.3)(jsdom@30.0.1)(lightningcss@1.33.0)(tsx@4.23.12)
 
+  packages/headlinearena:
+    dependencies:
+      '@deepseek-ai/cordis':
+        specifier: '>=4.0.0'
+        version: 4.0.2(@deepseek-ai/cordis-plugin-include@1.0.7)(@deepseek-ai/cordis-plugin-loader@1.0.3)
+      '@deepseek-ai/dsh-tools':
+        specifier: 0.1.2-rc.1
+        version: 0.1.2-rc.1(de5e1ff2d608fbe22667925341ad1dfc)
+      '@deepseek-ai/schemastery':
+        specifier: ^3.18.2
+        version: 3.18.2
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.14(tsx@4.23.12)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(@types/node@24.13.3)(jsdom@30.0.1)(lightningcss@1.33.0)(tsx@4.23.12)
+
   packages/hk:
     dependencies:
       '@deepseek-ai/cordis':

--- a/scripts/typecheck-baseline.json
+++ b/scripts/typecheck-baseline.json
@@ -46,6 +46,7 @@
   "packages/dsh-i18n/tsconfig.client.json": 0,
   "packages/dsh-i18n/tsconfig.json": 0,
   "packages/eventbus/tsconfig.json": 0,
+  "packages/headlinearena/tsconfig.json": 0,
   "packages/hk/tsconfig.json": 1,
   "packages/holdings/tsconfig.json": 0,
   "packages/indicator-supertrend/tsconfig.client.json": 3,


### PR DESCRIPTION
## 关联 Issue

Closes #66

---

## 概述与架构定位

针对 Issue #66（Headline Arena 创始人 Kopei 提出）：
1. **Pre-gate Judgment Audit（闸门前研判独立审计）**：
   `dsh-trading` 坚守“必须由人类手工审批”的交易纪律铁律；在审批闸门之前，Agent 形成的宏观研判与方向预判通过第三方市价机械结算平台（Headline Arena，3,700+ 笔已结算预测）沉淀不可篡改的公开履约战绩，解答用户“凭什么信任 Agent 研报”的疑虑。
2. **解耦交易连接器**：
   Headline Arena 不提供资金托管与真金撮合，将其定案为独立的**宏观预测基准与研判外审插件包**（`@dshtrading/headlinearena`），不污染 `TradeService` 交易契约。
3. **严格遵循五大铁律**：
   - 铁律 #1：增量引入，零改动既有 bundle patch；
   - 铁律 #2：随包发布 `headlinearena-audit` 技能；
   - 铁律 #3：工具层默认开启 `dryRun: true` 模拟保护，防意外数据外发；
   - 铁律 #4：宏观综合指标跨资产（GC/CL/ES/ZN/BTC）解耦于单一市场；
   - 铁律 #5：复用本地 `~/.headlinearena/credentials.json` 或环境变量，零密钥进代码库。

---

## 主要变更

### 1. 新建插件包 `@dshtrading/headlinearena`
- **`src/types.ts`**：挑战、预测契约、成绩单、状态及 Schema 严格类型（适配 `exactOptionalPropertyTypes: true`）；
- **`src/store.ts`**：本地凭据读取与自动升级（兼容多 Agent 字典与旧版扁平结构）；
- **`src/client.ts`**：基于 Fetch 的 REST 客户端，封装 OAuth2 Token 缓存与自动刷新；
- **`src/tools.ts`**：为 Agent 提供 4 项标准工具：
  - `ha_status`：查询凭证与 Agent 绑定状态；
  - `ha_list_challenges`：发现开放中的宏观期货挑战（黄金 GC、原油 CL、标普 ES、美债 ZN、比特币 BTC 等）；
  - `ha_submit_prediction`：将 Agent 研报观点存证提交至机械结算序列（自带 `dryRun` 保护）；
  - `ha_get_scorecard`：查询 Agent 历史预测的客观结算胜率、Brier 得分与战绩主页。
- **`src/plugin.ts`**：Cordis 插件实现与 Service 挂载。

### 2. 配套技能与决策记录
- **Skill**：`.agents/skills/headlinearena-audit/SKILL.md`；
- **Note**：`.agents/notes/implemented/features/2026-09-06-headlinearena-pregate-audit-plugin.md`。

---

## 验证与门禁结果

- **专属单测**：`pnpm --filter @dshtrading/headlinearena test` → **20/20 全部通过**；
- **构建打包**：`pnpm --filter @dshtrading/headlinearena build` → **编译通过，生成 ESM + .d.ts**；
- **TypeScript 棘轮门禁**：`node scripts/typecheck-gate.mjs` → **63 个 tsconfig 0 增量错误通过**；
- **全仓回归单测**：`pnpm test` → **135 个测试文件、1084 个测试用例全部通过**；
- **全仓构建**：`pnpm build` → **全仓通过**。
