### PR TITLE
feat(indicators): 激活实例支持按标的参数覆盖 symbolParams (#72)

### DIFF
--- a/.agents/notes/implemented/feature/2026-09-07-symbol-params.md
+++ b/.agents/notes/implemented/feature/2026-09-07-symbol-params.md
@@ -23,4 +23,15 @@ Status: implemented
 
 - 通用机制，预置与自定义指标均可按标的调参；`indicator_list` 的 active 名册自动带出 symbolParams。
 - GUI 暂不能在「无覆盖的标的」上直接创建覆盖（走 agent 工具或 bridge），编辑器提示只在已有覆盖时出现——后续如需 GUI 建覆盖，加「仅当前标的」开关即可，数据模型已就绪。
-- 测试：indicators 包 4 个 symbolParams 用例 + activate 工具按标的写/全局保留用例；client-ui-trading 桥端点 scope/clearSymbol/import 保真用例、chart-state scopeKey 用例。门禁 pnpm build / pnpm test（1120 过）/ i18n:check 全绿。
+- 测试：indicators 包 4 个 symbolParams 用例 + activate 工具按标的写/全局保留用例；client-ui-trading 桥端点 scope/clearSymbol/import 保真用例、chart-state scopeKey 用例。门禁 pnpm build / pnpm test / i18n:check 全绿。
+
+## Review hardening（2026-09-07 PR #73 复审修正）
+
+自查发现四个旁路问题，同分支修复：
+
+- **indicator_author activate:true 重挂不再抹覆盖**（tool.ts）：与 indicator_activate 全局写同语义——保留已有 symbolParams；re-author 改 schema 时按**新 schema 重 clamp** 每套覆盖（旧键丢弃、缺键补默认、越界收敛），stale 覆盖不直通 compute。
+- **读侧 clamp 兜底**（QuoteStage）：compute 前对生效参数按当前 definition schema 再 clamp（`indicators.clampParams`）——任何路径漏进的 stale 覆盖（手改 localStorage、老版本迁移）在渲染层最后收敛。
+- **bridge 半参 scope 业务拒绝**（`TRADING_INVALID_SCOPE`）：market/symbol 只给其一原来会静默落**全局**写（影响所有标的）；现与 indicator_activate 工具同规则成对校验。
+- **clearSymbol 对未挂载 id 是无操作**：原来会反向创建 schema 默认实例挂上图；现直接返回当前名册不写 store。
+
+裁决：bridge / indicator_activate 的全局写**保留**（不重 clamp）已有覆盖——读侧 clamp 已兜住渲染，store 保持「哑存储 + 写入边界 clamp」分层，避免每次写都隐式改写无关标的数据。

--- a/.agents/notes/implemented/feature/2026-09-07-symbol-params.md
+++ b/.agents/notes/implemented/feature/2026-09-07-symbol-params.md
@@ -1,0 +1,26 @@
+# Agent Note: 指标激活实例按标的参数覆盖（symbolParams）
+
+Status: implemented
+
+## Problem
+
+某些自定义指标的参数天然是按标的的（锚点类指标：每个标的有自己的一套锚点参数）。激活名册原模型是「每 id 一个实例一套全局 params」（issue #63），切标的后参数不变，这类指标无法按标的区分，退化为所有标的共用一套参数。
+
+## Decision
+
+`IndicatorInstance` 增加可选 `symbolParams: Record<"${market}:${symbol}", Record<string, number>>`（issue #72）：命中当前标的时该套参数**整体替代**全局 params，无覆盖回退全局。覆盖记录始终是 clamp 后的完整参数集（clampActivationParams 缺失键补默认值），不存在「部分覆盖再合并」的歧义。
+
+- 存储层：`sanitizeInstance` 统一深拷贝规范化（symbolParams 非法键/值只丢该字段不连累实例），内存/文件 store 与迁移导入（parseChartInstances 行保留语义不变）全链路保真。
+- 写入边界：bridge `PUT /chart/indicators` 与 `indicator_activate` 工具接受 market+symbol 写单标的覆盖（clearSymbol 删除）；不带 scope 写全局 params 且保留已有覆盖（修复旧行为整体覆盖会抹掉 symbolParams 的隐患）。**新实例的首个按标的写入，其全局 params 取 schema 默认值**——首个标的的覆盖不得泄漏成全局值。
+- 客户端：QuoteStage 计算指标用 `effectiveInstanceParams(instance, market, symbol)`；参数编辑器初值 = 当前标的生效参数，存在覆盖时展示「专属参数」提示（i18n key indicator.symbolOverride）；Apply 在已有覆盖时写覆盖、否则写全局。chart-state.setParams 增加可选 scopeKey，host-chart-sync 解析 scopeKey 透传 bridge。
+
+## Alternatives considered
+
+- **compute 第三参传 {market, symbol} 上下文、指标源码内嵌「标的→参数」映射**：改动最小（不动存储/桥/工具），但每次参数更新都要重新创作指标源码落库，参数脱离激活名册 SSOT，且映射表随源码分发，维护性与隐私边界都更差。
+- **部分覆盖（只存差分键、渲染时与全局合并）**：省存储但引入合并语义与「全局改键后覆盖意图漂移」的歧义；整体替代心智模型简单且 clamp 本就补全 schema。
+
+## Consequences
+
+- 通用机制，预置与自定义指标均可按标的调参；`indicator_list` 的 active 名册自动带出 symbolParams。
+- GUI 暂不能在「无覆盖的标的」上直接创建覆盖（走 agent 工具或 bridge），编辑器提示只在已有覆盖时出现——后续如需 GUI 建覆盖，加「仅当前标的」开关即可，数据模型已就绪。
+- 测试：indicators 包 4 个 symbolParams 用例 + activate 工具按标的写/全局保留用例；client-ui-trading 桥端点 scope/clearSymbol/import 保真用例、chart-state scopeKey 用例。门禁 pnpm build / pnpm test（1120 过）/ i18n:check 全绿。

--- a/packages/client-ui-trading/src/bridge.ts
+++ b/packages/client-ui-trading/src/bridge.ts
@@ -20,7 +20,7 @@ import { aggregateNews as aggregateHkNews, fetchHkFundamentalsPackage } from '@d
 import { aggregateNews as aggregateUsNews, fetchUsFundamentalsPackage } from '@dshtrading/kit-us'
 import { aggregateNews as aggregateCryptoNews, fetchCryptoFundamentalsPackage } from '@dshtrading/kit-crypto'
 import type { ChartActivationStore, CustomIndicatorRecord, CustomIndicatorStore, IndicatorInstance } from '@dshtrading/indicators'
-import { clampActivationParams, createMemoryChartActivationStore, createMemoryCustomIndicatorStore, resolveIndicatorSpec } from '@dshtrading/indicators'
+import { clampActivationParams, createMemoryChartActivationStore, createMemoryCustomIndicatorStore, resolveIndicatorSpec, sanitizeInstance, symbolScopeKey } from '@dshtrading/indicators'
 import type { KnowledgeCard, KnowledgeCardStore } from '@dshtrading/knowledge'
 import { createMemoryKnowledgeCardStore } from '@dshtrading/knowledge'
 import type { CustomStrategyRecord, CustomStrategyStore } from '@dshtrading/strategies'
@@ -1151,13 +1151,16 @@ export class TradingBridge {
   }
 
   /**
-   * 挂载/更新一个激活实例（PUT /chart/indicators，body { id, params? }）：
+   * 挂载/更新一个激活实例（PUT /chart/indicators，body { id, params?, market?, symbol?, clearSymbol? }）：
    * id 必须能解析为预置或自定义指标（未知 id 业务拒绝——与 GUI 可渲染集合同源）；
    * params 按 schema clamp，缺失键取 schema 默认值。
+   * issue #72：body 同时带 market+symbol 时写入该标的的参数覆盖（symbolParams[
+   * `${market}:${symbol}`]），clearSymbol:true 改为删除该覆盖；不带 scope 时写
+   * 全局 params。两种写法都保留实例上已有的其他覆盖。
    */
   async putChartActivation(body: unknown): Promise<ChartActivationsWire | ChartActivationRejectedWire> {
     const store = this.host.chartActivationsStore
-    const raw = (body ?? {}) as { id?: unknown; params?: unknown }
+    const raw = (body ?? {}) as { id?: unknown; params?: unknown; market?: unknown; symbol?: unknown; clearSymbol?: unknown }
     const id = typeof raw.id === 'string' ? raw.id.trim() : ''
     if (!id) throw new BridgeProtocolError(400, 'chart activation body requires string id')
     const spec = await resolveIndicatorSpec(id, this.host.customIndicatorsStore)
@@ -1175,7 +1178,26 @@ export class TradingBridge {
       }
     }
     const params = clampActivationParams(spec.params, overrides)
-    const instance: IndicatorInstance = { id, params }
+    const market = typeof raw.market === 'string' ? raw.market.trim() : ''
+    const symbol = typeof raw.symbol === 'string' ? raw.symbol.trim() : ''
+    const scope = market !== '' && symbol !== '' ? symbolScopeKey(market, symbol) : undefined
+    const existing = store !== undefined ? (await store.list()).find(instance => instance.id === id) : undefined
+
+    let instance: IndicatorInstance
+    if (scope !== undefined) {
+      // 新实例的全局 params 取 schema 默认值——首个标的的覆盖不得泄漏成全局值。
+      const base: IndicatorInstance = existing ?? { id, params: clampActivationParams(spec.params, {}) }
+      const symbolParams: Record<string, Record<string, number>> = { ...(base.symbolParams ?? {}) }
+      if (raw.clearSymbol === true) delete symbolParams[scope]
+      else symbolParams[scope] = params
+      instance = Object.keys(symbolParams).length > 0
+        ? { id, params: base.params, symbolParams }
+        : { id, params: base.params }
+    } else {
+      instance = existing?.symbolParams !== undefined
+        ? { id, params, symbolParams: existing.symbolParams }
+        : { id, params }
+    }
     if (store !== undefined) await store.activate(instance)
     return { ok: true, instances: store !== undefined ? await store.list() : [instance] }
   }
@@ -1292,7 +1314,9 @@ function parseChartInstances(body: unknown): IndicatorInstance[] {
     for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
       if (typeof value === 'number' && Number.isFinite(value)) clean[key] = value
     }
-    out.push({ id, params: clean })
+    // 行保留语义不变（脏值清洗成空 params），symbolParams 经 sanitizeInstance 保真（issue #72）。
+    const normalized = sanitizeInstance({ id, params: clean, symbolParams: (item as { symbolParams?: unknown }).symbolParams })
+    if (normalized !== undefined) out.push(normalized)
   }
   return out
 }

--- a/packages/client-ui-trading/src/bridge.ts
+++ b/packages/client-ui-trading/src/bridge.ts
@@ -262,7 +262,7 @@ export interface ChartActivationsWire {
 /** 图表激活写入的业务拒绝（未知指标 id 等；协议错误仍走 BridgeProtocolError）。 */
 export interface ChartActivationRejectedWire {
   ok: false
-  code: 'TRADING_UNKNOWN_INDICATOR'
+  code: 'TRADING_UNKNOWN_INDICATOR' | 'TRADING_INVALID_SCOPE'
   message: string
 }
 
@@ -1156,7 +1156,8 @@ export class TradingBridge {
    * params 按 schema clamp，缺失键取 schema 默认值。
    * issue #72：body 同时带 market+symbol 时写入该标的的参数覆盖（symbolParams[
    * `${market}:${symbol}`]），clearSymbol:true 改为删除该覆盖；不带 scope 时写
-   * 全局 params。两种写法都保留实例上已有的其他覆盖。
+   * 全局 params。两种写法都保留实例上已有的其他覆盖。market/symbol 只给其一是
+   * 业务拒绝（TRADING_INVALID_SCOPE）；clearSymbol 对未挂载 id 是无操作不建实例。
    */
   async putChartActivation(body: unknown): Promise<ChartActivationsWire | ChartActivationRejectedWire> {
     const store = this.host.chartActivationsStore
@@ -1181,10 +1182,24 @@ export class TradingBridge {
     const market = typeof raw.market === 'string' ? raw.market.trim() : ''
     const symbol = typeof raw.symbol === 'string' ? raw.symbol.trim() : ''
     const scope = market !== '' && symbol !== '' ? symbolScopeKey(market, symbol) : undefined
+    if (scope === undefined && (market !== '' || symbol !== '')) {
+      // 与 indicator_activate 工具同规则：scope 只收成对 market+symbol，
+      // 半参业务拒绝而非静默落全局（全局写影响所有标的）。
+      return {
+        ok: false,
+        code: 'TRADING_INVALID_SCOPE',
+        message: 'market and symbol must be supplied together (or neither) — got market='
+          + JSON.stringify(market) + ', symbol=' + JSON.stringify(symbol),
+      }
+    }
     const existing = store !== undefined ? (await store.list()).find(instance => instance.id === id) : undefined
 
     let instance: IndicatorInstance
     if (scope !== undefined) {
+      // 清除不存在的覆盖是无操作：不反向创建激活实例。
+      if (raw.clearSymbol === true && existing === undefined) {
+        return { ok: true, instances: store !== undefined ? await store.list() : [] }
+      }
       // 新实例的全局 params 取 schema 默认值——首个标的的覆盖不得泄漏成全局值。
       const base: IndicatorInstance = existing ?? { id, params: clampActivationParams(spec.params, {}) }
       const symbolParams: Record<string, Record<string, number>> = { ...(base.symbolParams ?? {}) }

--- a/packages/client-ui-trading/src/client/MiddleStage.tsx
+++ b/packages/client-ui-trading/src/client/MiddleStage.tsx
@@ -50,7 +50,7 @@ export interface MiddleStageInjected {
     chart: Observable<ChartState>
   }
   toggleIndicator: (id: string) => void
-  setIndicatorParams: (id: string, params: Record<string, number>) => void
+  setIndicatorParams: (id: string, params: Record<string, number>, scopeKey?: string) => void
   /** 删除自定义指标（issue #30，透传给 QuoteStage 指标选择器）。 */
   deleteIndicator: (id: string) => Promise<boolean>
   /** 行情上下文 → 会话输入框（透传给 QuoteStage「发给 Agent」，只填入不发送）。 */

--- a/packages/client-ui-trading/src/client/QuotePane.tsx
+++ b/packages/client-ui-trading/src/client/QuotePane.tsx
@@ -27,7 +27,7 @@ export interface QuotePaneInjected {
     chart: Observable<ChartState>
   }
   toggleIndicator: (id: string) => void
-  setIndicatorParams: (id: string, params: Record<string, number>) => void
+  setIndicatorParams: (id: string, params: Record<string, number>, scopeKey?: string) => void
   /** 删除自定义指标（issue #30）：桥 DELETE → 注销注册表 + 移除激活实例。 */
   deleteIndicator: (id: string) => Promise<boolean>
   /** 行情上下文 → 会话输入框（只填入不发送；shell 注入）。 */

--- a/packages/client-ui-trading/src/client/QuoteStage.tsx
+++ b/packages/client-ui-trading/src/client/QuoteStage.tsx
@@ -33,6 +33,7 @@ import {
 } from './format.ts'
 import { indicators, isCustomIndicator } from './indicator-registry.ts'
 import type { IndicatorDefinition, IndicatorInstance } from '@dshtrading/indicators'
+import { effectiveInstanceParams, symbolScopeKey } from '@dshtrading/indicators'
 import { MARKET_INTERVALS } from './store.ts'
 import type { SelectionState } from './store.ts'
 import type { ChartState } from './chart-state.ts'
@@ -100,7 +101,7 @@ export interface QuoteStageProps {
   useSelection: UseStoreState<SelectionState>
   useChart: UseStoreState<ChartState>
   toggleIndicator: (id: string) => void
-  setIndicatorParams: (id: string, params: Record<string, number>) => void
+  setIndicatorParams: (id: string, params: Record<string, number>, scopeKey?: string) => void
   /** 删除自定义指标（issue #30 删除入口；仅自定义行渲染按钮）。 */
   deleteIndicator: (id: string) => Promise<boolean>
   /** 行情上下文 → 会话输入框（只填入不发送；shell 注入，缺席时按钮不渲染）。 */
@@ -587,11 +588,12 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
         title: definition.title,
         pane: definition.pane,
         key: indicators.instanceKey(instance),
-        outputs: definition.compute(klines, instance.params),
+        // issue #72：命中 symbolParams["market:symbol"] 覆盖时该套参数整体替代全局 params。
+        outputs: definition.compute(klines, effectiveInstanceParams(instance, market, symbol)),
       })
     }
     return groups
-  }, [klines, instances, rosterVersion])
+  }, [klines, instances, rosterVersion, market, symbol])
 
   const mainOverlays = useMemo(() => indicatorGroups.filter(group => group.pane === 'main'), [indicatorGroups])
   const subIndicators = useMemo(() => indicatorGroups.filter(group => group.pane === 'sub'), [indicatorGroups])
@@ -1086,13 +1088,19 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
                   t={t}
                   instances={instances}
                   editingIndicator={editingIndicator}
+                  scopeKey={market !== undefined && symbol !== undefined ? symbolScopeKey(market, symbol) : undefined}
+                  symbolLabel={symbol}
                   onToggle={(id) => {
                     toggleIndicator(id)
                     setEditingIndicator(null)
                   }}
                   onEdit={(id) => { setEditingIndicator(current => current === id ? null : id) }}
                   onApply={(id, params) => {
-                    setIndicatorParams(id, params)
+                    // issue #72：当前标的已有参数覆盖 → 写覆盖；否则写全局 params。
+                    const scopeKey = market !== undefined && symbol !== undefined ? symbolScopeKey(market, symbol) : undefined
+                    const instance = instances.find(candidate => candidate.id === id)
+                    const hasOverride = scopeKey !== undefined && instance?.symbolParams?.[scopeKey] !== undefined
+                    setIndicatorParams(id, params, hasOverride ? scopeKey : undefined)
                     setEditingIndicator(null)
                   }}
                   onDelete={(id) => { void deleteIndicator(id) }}
@@ -1355,13 +1363,17 @@ function IndicatorPicker(props: {
   t: Translate
   instances: IndicatorInstance[]
   editingIndicator: string | null
+  /** 当前标的的 scope 键（`${market}:${symbol}`）；undefined = 无聚焦标的。 */
+  scopeKey?: string | undefined
+  /** 当前标的 symbol（覆盖提示文案用）。 */
+  symbolLabel?: string | undefined
   onToggle: (id: string) => void
   onEdit: (id: string) => void
   onApply: (id: string, params: Record<string, number>) => void
   onDelete: (id: string) => void
   onClose: () => void
 }): React.JSX.Element {
-  const { t, instances, editingIndicator, onToggle, onEdit, onApply, onDelete, onClose } = props
+  const { t, instances, editingIndicator, scopeKey, symbolLabel, onToggle, onEdit, onApply, onDelete, onClose } = props
   const definitions = indicators.list()
   const empty = definitions.length === 0
   return (
@@ -1378,6 +1390,8 @@ function IndicatorPicker(props: {
               definitions={definitions.filter(definition => definition.pane === 'main')}
               instances={instances}
               editingIndicator={editingIndicator}
+              scopeKey={scopeKey}
+              symbolLabel={symbolLabel}
               t={t}
               onToggle={onToggle}
               onEdit={onEdit}
@@ -1389,6 +1403,8 @@ function IndicatorPicker(props: {
               definitions={definitions.filter(definition => definition.pane === 'sub')}
               instances={instances}
               editingIndicator={editingIndicator}
+              scopeKey={scopeKey}
+              symbolLabel={symbolLabel}
               t={t}
               onToggle={onToggle}
               onEdit={onEdit}
@@ -1407,19 +1423,23 @@ function PickerGroup(props: {
   definitions: readonly IndicatorDefinition[]
   instances: readonly IndicatorInstance[]
   editingIndicator: string | null
+  scopeKey?: string | undefined
+  symbolLabel?: string | undefined
   t: Translate
   onToggle: (id: string) => void
   onEdit: (id: string) => void
   onApply: (id: string, params: Record<string, number>) => void
   onDelete: (id: string) => void
 }): React.JSX.Element {
-  const { title, definitions, instances, editingIndicator, t, onToggle, onEdit, onApply, onDelete } = props
+  const { title, definitions, instances, editingIndicator, scopeKey, symbolLabel, t, onToggle, onEdit, onApply, onDelete } = props
   return (
     <div className={css.pickerGroup}>
       <div className={css.pickerGroupTitle}>{title}</div>
       {definitions.map(definition => {
         const instance = instances.find(candidate => candidate.id === definition.id) ?? null
         const editing = editingIndicator === definition.id
+        // issue #72：编辑器初值 = 当前标的生效参数（覆盖优先），有覆盖时展示提示。
+        const scopedParams = instance !== null && scopeKey !== undefined ? instance.symbolParams?.[scopeKey] : undefined
         return (
           <div key={definition.id} className={css.pickerRow}>
             <label className={css.pickerLabel}>
@@ -1456,7 +1476,10 @@ function PickerGroup(props: {
             {editing && instance !== null && (
               <IndicatorParamEditor
                 definition={definition}
-                initial={instance.params}
+                initial={scopedParams ?? instance.params}
+                overrideHint={scopedParams !== undefined && symbolLabel !== undefined
+                  ? t('indicator.symbolOverride', { symbol: symbolLabel })
+                  : undefined}
                 t={t}
                 onCancel={() => onEdit(definition.id)}
                 onApply={(params) => onApply(definition.id, params)}
@@ -1472,6 +1495,8 @@ function PickerGroup(props: {
 function IndicatorParamEditor(props: {
   definition: IndicatorDefinition
   initial: Record<string, number>
+  /** issue #72：当前编辑的是某标的的专属覆盖时展示的提示文案。 */
+  overrideHint?: string | undefined
   t: Translate
   onCancel: () => void
   onApply: (params: Record<string, number>) => void
@@ -1485,6 +1510,7 @@ function IndicatorParamEditor(props: {
 
   return (
     <div className={css.paramEditor}>
+      {props.overrideHint !== undefined && <div className={css.paramHint}>{props.overrideHint}</div>}
       {definition.params.map(spec => (
         <label key={spec.key} className={css.paramRow}>
           <span>{spec.label}</span>

--- a/packages/client-ui-trading/src/client/QuoteStage.tsx
+++ b/packages/client-ui-trading/src/client/QuoteStage.tsx
@@ -588,8 +588,9 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
         title: definition.title,
         pane: definition.pane,
         key: indicators.instanceKey(instance),
-        // issue #72：命中 symbolParams["market:symbol"] 覆盖时该套参数整体替代全局 params。
-        outputs: definition.compute(klines, effectiveInstanceParams(instance, market, symbol)),
+        // issue #72：命中 symbolParams["market:symbol"] 覆盖时该套参数整体替代全局 params；
+        // 计算前按当前 schema clamp——re-author 改 schema 后 stale 覆盖的旧键/越界值不直通 compute。
+        outputs: definition.compute(klines, indicators.clampParams(definition, effectiveInstanceParams(instance, market, symbol))),
       })
     }
     return groups

--- a/packages/client-ui-trading/src/client/api.ts
+++ b/packages/client-ui-trading/src/client/api.ts
@@ -447,13 +447,24 @@ export async function fetchChartActivations(): Promise<IndicatorInstance[]> {
   }
 }
 
-/** 挂载/更新一个激活实例（PUT /chart/indicators；未知 id → ok:false，转 false）。 */
-export async function putChartActivation(id: string, params?: Record<string, number>): Promise<boolean> {
+/**
+ * 挂载/更新一个激活实例（PUT /chart/indicators；未知 id → ok:false，转 false）。
+ * issue #72：带 scope（market+symbol）时写该标的的参数覆盖，不动全局 params。
+ */
+export async function putChartActivation(
+  id: string,
+  params?: Record<string, number>,
+  scope?: { market: string; symbol: string },
+): Promise<boolean> {
   try {
     const response = await fetch('/dshtrading/api/chart/indicators', {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ id, ...(params !== undefined ? { params } : {}) }),
+      body: JSON.stringify({
+        id,
+        ...(params !== undefined ? { params } : {}),
+        ...(scope !== undefined ? { market: scope.market, symbol: scope.symbol } : {}),
+      }),
     })
     if (!response.ok) return false
     const wire = await response.json() as { ok?: boolean }

--- a/packages/client-ui-trading/src/client/chart-state.ts
+++ b/packages/client-ui-trading/src/client/chart-state.ts
@@ -22,8 +22,12 @@ export interface ChartState {
 export interface ChartStateStore extends WritableObservable<ChartState> {
   /** 切换某 preset：无实例 → 加默认实例；有 → 全部移除。 */
   togglePreset(id: string): void
-  /** 更新（或补建）某 preset 的唯一实例参数。 */
-  setParams(id: string, params: Record<string, number>): void
+  /**
+   * 更新（或补建）某 preset 的唯一实例参数。
+   * issue #72：带 scopeKey（`${market}:${symbol}`）时写该标的的参数覆盖，
+   * 全局 params 与其它标的覆盖保持不变；不带 scopeKey 写全局 params 并保留覆盖表。
+   */
+  setParams(id: string, params: Record<string, number>, scopeKey?: string): void
   /** 移除某 preset 的激活实例（自定义指标删除用；无实例时静默）。 */
   removeInstance(id: string): void
   instanceFor(id: string): IndicatorInstance | undefined
@@ -54,13 +58,22 @@ export function createChartStateStore(registry: IndicatorRegistry): ChartStateSt
       })
       persist()
     },
-    setParams(id, params) {
+    setParams(id, params, scopeKey) {
       const definition = registry.get(id)
       const clamped = definition !== undefined ? registry.clampParams(definition, params) : params
       store.update((current) => {
-        const exists = current.instances.some(instance => instance.id === id)
-        return { instances: exists
-          ? current.instances.map(instance => instance.id === id ? { id, params: clamped } : instance)
+        const existing = current.instances.find(instance => instance.id === id)
+        if (scopeKey !== undefined) {
+          if (existing === undefined) {
+            const baseParams = definition !== undefined ? registry.defaultParams(definition) : {}
+            return { instances: [...current.instances, { id, params: baseParams, symbolParams: { [scopeKey]: clamped } }] }
+          }
+          return { instances: current.instances.map(instance => instance.id === id
+            ? { ...instance, symbolParams: { ...(instance.symbolParams ?? {}), [scopeKey]: clamped } }
+            : instance) }
+        }
+        return { instances: existing !== undefined
+          ? current.instances.map(instance => instance.id === id ? { ...instance, params: clamped } : instance)
           : [...current.instances, { id, params: clamped }] }
       })
       persist()

--- a/packages/client-ui-trading/src/client/contract.ts
+++ b/packages/client-ui-trading/src/client/contract.ts
@@ -512,6 +512,7 @@ export type MarketLocaleKey =
   | 'indicator.params'
   | 'indicator.apply'
   | 'indicator.cancel'
+  | 'indicator.symbolOverride'
   | 'indicator.delete'
   | 'indicator.deleteConfirm'
   | 'interval.1m'

--- a/packages/client-ui-trading/src/client/host-chart-sync.ts
+++ b/packages/client-ui-trading/src/client/host-chart-sync.ts
@@ -80,10 +80,15 @@ export function wireHostChartSync(options: HostChartSyncOptions): () => void {
     })()
   }
   const originalSetParams = chart.setParams.bind(chart)
-  chart.setParams = (id: string, params: Record<string, number>): void => {
+  chart.setParams = (id: string, params: Record<string, number>, scopeKey?: string): void => {
     void (async () => {
-      const ok = await putChartActivation(id, params)
-      if (ok) originalSetParams(id, params)
+      // scopeKey = "<market>:<symbol>"（issue #72）：写该标的覆盖；缺省写全局。
+      const split = scopeKey !== undefined ? scopeKey.indexOf(':') : -1
+      const scope = split > 0 && scopeKey !== undefined
+        ? { market: scopeKey.slice(0, split), symbol: scopeKey.slice(split + 1) }
+        : undefined
+      const ok = await putChartActivation(id, params, scope)
+      if (ok) originalSetParams(id, params, scopeKey)
       else console.warn('[dsh-trading] chart param update failed on host — local state unchanged')
     })()
   }

--- a/packages/client-ui-trading/src/client/index.ts
+++ b/packages/client-ui-trading/src/client/index.ts
@@ -281,7 +281,7 @@ export function apply(ctx: ClientContext): void {
     inject: () => ({
       hooks: { selection, chart },
       toggleIndicator: (id) => { chart.togglePreset(id) },
-      setIndicatorParams: (id, params) => { chart.setParams(id, params) },
+      setIndicatorParams: (id, params, scopeKey) => { chart.setParams(id, params, scopeKey) },
       deleteIndicator: async (id) => {
         const ok = await deleteCustomIndicator(id)
         if (ok) {

--- a/packages/client-ui-trading/src/client/locales.ts
+++ b/packages/client-ui-trading/src/client/locales.ts
@@ -605,6 +605,7 @@ export const zh: Record<MarketLocaleKey, string> = {
       'indicator.cancel': '取消',
       'indicator.delete': '删除',
       'indicator.deleteConfirm': '确定删除该自定义指标？已持久化的定义将从指标库移除。',
+      'indicator.symbolOverride': '当前为 {symbol} 的专属参数（仅对该标的生效）',
 }
 
 export const en: Record<MarketLocaleKey, string> = {
@@ -1205,4 +1206,5 @@ export const en: Record<MarketLocaleKey, string> = {
       'indicator.cancel': 'Cancel',
       'indicator.delete': 'Delete',
       'indicator.deleteConfirm': 'Delete this custom indicator? The persisted definition will be removed from the library.',
+      'indicator.symbolOverride': 'Editing symbol-specific params for {symbol} (applies to this instrument only)',
 }

--- a/packages/client-ui-trading/src/client/quote-stage.module.css
+++ b/packages/client-ui-trading/src/client/quote-stage.module.css
@@ -549,6 +549,12 @@
   background: var(--dsw-futu-bg-surface-hover, rgba(0, 0, 0, 0.05));
 }
 
+.paramHint {
+  font-size: 11px;
+  color: var(--dsh-text-secondary, #8a8f99);
+  margin-bottom: 6px;
+}
+
 .paramEditor {
   width: 100%;
   display: flex;

--- a/packages/client-ui-trading/test/chart-activations.test.ts
+++ b/packages/client-ui-trading/test/chart-activations.test.ts
@@ -122,6 +122,24 @@ describe('图表激活名册桥端点（issue #63）', () => {
     expect(list).toEqual({ status: 200, payload: { ok: true, instances: [{ id: 'td9', params: { count: 12 } }] } })
   })
 
+  it('PUT 半参 scope（只给 market）→ 业务拒绝 TRADING_INVALID_SCOPE，不落盘（issue #72 复审）', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    const wire = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'td9', market: 'hk', params: { count: 11 } })
+    expect(wire).toMatchObject({ status: 200, payload: { ok: false, code: 'TRADING_INVALID_SCOPE' } })
+    const list = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(list).toEqual({ status: 200, payload: { ok: true, instances: [] } })
+  })
+
+  it('PUT clearSymbol 对未挂载 id 是无操作，不反向创建实例（issue #72 复审）', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    const wire = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'td9', market: 'hk', symbol: '00700.HK', clearSymbol: true })
+    expect(wire).toEqual({ status: 200, payload: { ok: true, instances: [] } })
+    const list = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(list).toEqual({ status: 200, payload: { ok: true, instances: [] } })
+  })
+
   it('POST import 保真 symbolParams（issue #72 迁移不丢覆盖）', async () => {
     const bridge = new TradingBridge(fakeHost())
     await dispatchBridgeRequest(bridge, 'POST', '/chart/indicators/import', new URLSearchParams(), {

--- a/packages/client-ui-trading/test/chart-activations.test.ts
+++ b/packages/client-ui-trading/test/chart-activations.test.ts
@@ -83,6 +83,60 @@ describe('图表激活名册桥端点（issue #63）', () => {
     expect(second).toMatchObject({ status: 200, payload: { ok: false, imported: false } })
   })
 
+  it('PUT 按标的覆盖（issue #72）：market+symbol 写 symbolParams；clearSymbol 删除；全局写保留覆盖', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    // 按标的写入两套覆盖
+    await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'td9', market: 'hk', symbol: '00700.HK', params: { count: 11 } })
+    const wire = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'td9', market: 'us', symbol: 'GOOGL', params: { count: 10 } })
+    expect(wire).toEqual({
+      status: 200,
+      payload: {
+        ok: true,
+        instances: [{
+          id: 'td9', params: { count: 9 },
+          symbolParams: { 'hk:00700.HK': { count: 11 }, 'us:GOOGL': { count: 10 } },
+        }],
+      },
+    })
+    // 全局写更新 params 且保留覆盖
+    await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), { id: 'td9', params: { count: 12 } })
+    let list = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(list).toEqual({
+      status: 200,
+      payload: {
+        ok: true,
+        instances: [{
+          id: 'td9', params: { count: 12 },
+          symbolParams: { 'hk:00700.HK': { count: 11 }, 'us:GOOGL': { count: 10 } },
+        }],
+      },
+    })
+    // clearSymbol 删除单标的覆盖；清空后 symbolParams 字段整体消失
+    await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'td9', market: 'hk', symbol: '00700.HK', clearSymbol: true })
+    await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'td9', market: 'us', symbol: 'GOOGL', clearSymbol: true })
+    list = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(list).toEqual({ status: 200, payload: { ok: true, instances: [{ id: 'td9', params: { count: 12 } }] } })
+  })
+
+  it('POST import 保真 symbolParams（issue #72 迁移不丢覆盖）', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    await dispatchBridgeRequest(bridge, 'POST', '/chart/indicators/import', new URLSearchParams(), {
+      instances: [{ id: 'td9', params: { count: 9 }, symbolParams: { 'hk:00700.HK': { count: 11 }, '': { count: 1 } } }],
+    })
+    const list = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(list).toEqual({
+      status: 200,
+      payload: {
+        ok: true,
+        instances: [{ id: 'td9', params: { count: 9 }, symbolParams: { 'hk:00700.HK': { count: 11 } } }],
+      },
+    })
+  })
+
   it('桥缺 chartActivationsStore（老部署）→ 端点静默降级不崩', async () => {
     const bridge = new TradingBridge(fakeHost({ chartActivationsStore: undefined }))
     const put = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), { id: 'ma' })

--- a/packages/client-ui-trading/test/chart-state.test.ts
+++ b/packages/client-ui-trading/test/chart-state.test.ts
@@ -40,6 +40,26 @@ describe('chart-state store', () => {
     expect(store.instanceFor('rsi')).toEqual({ id: 'rsi', params: { n: 6 } })
   })
 
+  it('setParams 带 scopeKey 写按标的覆盖（issue #72）；全局写保留覆盖表', () => {
+    const store = makeStore()
+    // 已有全局实例 → 写覆盖不动全局 params
+    store.setParams('ma', { n1: 7 }, 'hk:00700.HK')
+    expect(store.instanceFor('ma')).toEqual({
+      id: 'ma',
+      params: { n1: 5, n2: 10, n3: 20, n4: 30, n5: 60, n6: 120 },
+      symbolParams: { 'hk:00700.HK': { n1: 7, n2: 10, n3: 20, n4: 30, n5: 60, n6: 120 } },
+    })
+    // 全局写保留覆盖
+    store.setParams('ma', { n1: 8 })
+    expect(store.instanceFor('ma')?.params.n1).toBe(8)
+    expect(store.instanceFor('ma')?.symbolParams?.['hk:00700.HK']?.n1).toBe(7)
+    // 未激活实例带 scopeKey → 补建全局默认 + 该标的覆盖
+    store.setParams('rsi', { n: 6 }, 'us:GOOGL')
+    expect(store.instanceFor('rsi')).toEqual({
+      id: 'rsi', params: { n: 14 }, symbolParams: { 'us:GOOGL': { n: 6 } },
+    })
+  })
+
   it('未知 id 的 toggle/setParams 为无 default/clamp 原样落盘（防御手改 localStorage）', () => {
     const store = makeStore()
     store.togglePreset('ghost')

--- a/packages/indicators/src/chart-activations-fs.ts
+++ b/packages/indicators/src/chart-activations-fs.ts
@@ -6,6 +6,7 @@ import { readFile, writeFile, rename, mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { IndicatorInstance } from './types.ts'
 import type { ChartActivationStore } from './chart-activations.ts'
+import { sanitizeInstance } from './chart-activations.ts'
 
 export function createFileChartActivationStore(filePath: string): ChartActivationStore {
   let cache: Map<string, IndicatorInstance> | null = null
@@ -18,9 +19,8 @@ export function createFileChartActivationStore(filePath: string): ChartActivatio
       const map = new Map<string, IndicatorInstance>()
       if (Array.isArray(parsed)) {
         for (const item of parsed) {
-          if (item && typeof item === 'object' && typeof (item as { id?: unknown }).id === 'string') {
-            map.set((item as { id: string }).id, item as IndicatorInstance)
-          }
+          const clean = sanitizeInstance(item)
+          if (clean !== undefined) map.set(clean.id, clean)
         }
       }
       cache = map
@@ -64,11 +64,15 @@ export function createFileChartActivationStore(filePath: string): ChartActivatio
   return {
     async list() {
       const map = await load()
-      return [...map.values()].map(instance => ({ id: instance.id, params: { ...instance.params } }))
+      return [...map.values()].map(instance => sanitizeInstance(instance) as IndicatorInstance)
     },
     async activate(instance) {
+      const clean = sanitizeInstance(instance)
+      if (clean === undefined) {
+        throw new Error('chart activation: invalid instance shape for id ' + JSON.stringify((instance as { id?: unknown } | null | undefined)?.id))
+      }
       const map = await load()
-      map.set(instance.id, { id: instance.id, params: { ...instance.params } })
+      map.set(clean.id, clean)
       await flush(map)
     },
     async deactivate(id) {
@@ -79,7 +83,10 @@ export function createFileChartActivationStore(filePath: string): ChartActivatio
     },
     async replaceAll(instances) {
       const map = new Map<string, IndicatorInstance>()
-      for (const item of instances) map.set(item.id, { id: item.id, params: { ...item.params } })
+      for (const item of instances) {
+        const clean = sanitizeInstance(item)
+        if (clean !== undefined) map.set(clean.id, clean)
+      }
       cache = map
       await flush(map)
     },

--- a/packages/indicators/src/chart-activations.ts
+++ b/packages/indicators/src/chart-activations.ts
@@ -43,6 +43,50 @@ function isValidInstance(raw: unknown): raw is IndicatorInstance {
   return Object.values(params as Record<string, unknown>).every(v => typeof v === 'number' && Number.isFinite(v))
 }
 
+/** 按标的覆盖表防御性清洗（issue #72）：非法键/值整体丢弃该字段，不连累实例本体。 */
+function sanitizeSymbolParams(raw: unknown): Record<string, Record<string, number>> | undefined {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return undefined
+  const out: Record<string, Record<string, number>> = {}
+  for (const [scope, params] of Object.entries(raw as Record<string, unknown>)) {
+    if (scope.trim() === '' || typeof params !== 'object' || params === null || Array.isArray(params)) continue
+    const clean: Record<string, number> = {}
+    for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
+      if (typeof value === 'number' && Number.isFinite(value)) clean[key] = value
+    }
+    if (Object.keys(clean).length > 0) out[scope] = clean
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+/** 深拷贝规范化一个实例（params/symbolParams 均脱引用）；坏形返回 undefined。 */
+export function sanitizeInstance(raw: unknown): IndicatorInstance | undefined {
+  if (!isValidInstance(raw)) return undefined
+  const params = { ...(raw.params as Record<string, number>) }
+  const symbolParams = sanitizeSymbolParams((raw as { symbolParams?: unknown }).symbolParams)
+  return symbolParams !== undefined ? { id: raw.id, params, symbolParams } : { id: raw.id, params }
+}
+
+/** 按标的覆盖的 scope 键：`${market}:${symbol}`（与 client QuoteStage 的 market/symbol 同源）。 */
+export function symbolScopeKey(market: string, symbol: string): string {
+  return market + ':' + symbol
+}
+
+/**
+ * 实例对某标的的生效参数（issue #72）：symbolParams 命中 `${market}:${symbol}`
+ * 时整体替代全局 params；market/symbol 缺失或无覆盖 → 全局 params。
+ */
+export function effectiveInstanceParams(
+  instance: IndicatorInstance,
+  market?: string,
+  symbol?: string,
+): Record<string, number> {
+  if (market !== undefined && symbol !== undefined && instance.symbolParams !== undefined) {
+    const scoped = instance.symbolParams[symbolScopeKey(market, symbol)]
+    if (scoped !== undefined) return scoped
+  }
+  return instance.params
+}
+
 /** 内存版激活名册存储（纯浏览器与单测用）。 */
 export function createMemoryChartActivationStore(initial: IndicatorInstance[] = []): ChartActivationStore {
   const map = new Map<string, IndicatorInstance>()
@@ -51,19 +95,21 @@ export function createMemoryChartActivationStore(initial: IndicatorInstance[] = 
   }
 
   return {
-    list: async () => [...map.values()].map(instance => ({ id: instance.id, params: { ...instance.params } })),
+    list: async () => [...map.values()].map(instance => sanitizeInstance(instance) as IndicatorInstance),
     activate: async (instance) => {
-      if (!isValidInstance(instance)) {
+      const clean = sanitizeInstance(instance)
+      if (clean === undefined) {
         const id = (instance as { id?: unknown } | null | undefined)?.id
         throw new Error('chart activation: invalid instance shape for id ' + JSON.stringify(id))
       }
-      map.set(instance.id, { id: instance.id, params: { ...instance.params } })
+      map.set(clean.id, clean)
     },
     deactivate: async (id) => map.delete(id),
     replaceAll: async (instances) => {
       map.clear()
       for (const item of instances) {
-        if (isValidInstance(item)) map.set(item.id, { id: item.id, params: { ...item.params } })
+        const clean = sanitizeInstance(item)
+        if (clean !== undefined) map.set(clean.id, clean)
       }
     },
   }

--- a/packages/indicators/src/chart-tools.ts
+++ b/packages/indicators/src/chart-tools.ts
@@ -7,7 +7,8 @@
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import type { CustomIndicatorStore } from './custom.ts'
 import type { ChartActivationStore } from './chart-activations.ts'
-import { clampActivationParams, defaultActivationInstance, resolveIndicatorSpec } from './chart-activations.ts'
+import { clampActivationParams, defaultActivationInstance, resolveIndicatorSpec, symbolScopeKey } from './chart-activations.ts'
+import type { IndicatorInstance } from './types.ts'
 import { presetDefinitions } from './presets.ts'
 
 export interface IndicatorListToolOptions {
@@ -69,6 +70,8 @@ export function createIndicatorActivateTool(options: IndicatorActivateToolOption
       + 'The id must be a preset indicator or a custom indicator authored via indicator_author. '
       + 'Activating an already-active id updates its parameters in place (one instance per id). '
       + 'Optionally pass paramsJson to override schema defaults; values are clamped to each parameter\'s min/max. '
+      + 'Pass market AND symbol together to write a per-symbol parameter override (for indicators whose params are per-instrument): '
+      + 'the override replaces the global params when that instrument is on the chart; other instruments keep the global params. '
       + 'Use indicator_list to discover ids and parameter schemas.',
     parameters: {
       id: {
@@ -80,16 +83,31 @@ export function createIndicatorActivateTool(options: IndicatorActivateToolOption
         type: 'string',
         description: 'Optional JSON object of parameter overrides, e.g. {"fast":12,"slow":26,"signal":9}. Missing keys use schema defaults.',
       },
+      market: {
+        type: 'string',
+        description: 'Optional market vocabulary slug (crypto | us | cn | hk). Must be supplied together with symbol to write a per-symbol override.',
+      },
+      symbol: {
+        type: 'string',
+        description: 'Optional market-canonical symbol exactly as the chart uses it (e.g. "00700.HK", "002714.SZ", "AAPL"). Requires market.',
+      },
     },
     output: {
       schema: { type: 'string' },
       render: (_args, value) => [{ type: 'text', text: String(value) }],
     },
     async execute(raw) {
-      const args = (raw ?? {}) as { id?: unknown; paramsJson?: unknown }
+      const args = (raw ?? {}) as { id?: unknown; paramsJson?: unknown; market?: unknown; symbol?: unknown }
       const id = typeof args.id === 'string' ? args.id.trim() : ''
       if (!id) {
         throw new Error('indicator_activate: id is required')
+      }
+      const market = typeof args.market === 'string' ? args.market.trim() : ''
+      const symbol = typeof args.symbol === 'string' ? args.symbol.trim() : ''
+      const scope = market !== '' && symbol !== '' ? symbolScopeKey(market, symbol) : undefined
+      if (scope === undefined && (market !== '' || symbol !== '')) {
+        return '[indicator_activate] market and symbol must be supplied together (or neither) — got market='
+          + JSON.stringify(market) + ', symbol=' + JSON.stringify(symbol)
       }
       const spec = await resolveIndicatorSpec(id, customStore)
       if (spec === undefined) {
@@ -118,12 +136,25 @@ export function createIndicatorActivateTool(options: IndicatorActivateToolOption
       }
 
       const params = clampActivationParams(spec.params, overrides)
-      await chartStore.activate({ id, params })
+      let instance: IndicatorInstance
+      if (scope !== undefined) {
+        // 按标的覆盖（issue #72）：保留全局 params 与其它标的的覆盖，只写本标的这套。
+        // 新实例的全局 params 取 schema 默认值——首个标的的覆盖不得泄漏成全局值。
+        const existing = (await chartStore.list()).find(candidate => candidate.id === id)
+        const base: IndicatorInstance = existing ?? { id, params: clampActivationParams(spec.params, {}) }
+        instance = { id, params: base.params, symbolParams: { ...(base.symbolParams ?? {}), [scope]: params } }
+      } else {
+        // 全局写：保留已有按标的覆盖（旧行为直接整体覆盖实例会把 symbolParams 抹掉）。
+        const existing = (await chartStore.list()).find(candidate => candidate.id === id)
+        instance = existing?.symbolParams !== undefined ? { id, params, symbolParams: existing.symbolParams } : { id, params }
+      }
+      await chartStore.activate(instance)
       onWritten?.(id)
 
       const paramText = spec.params.map(p => (p.key + '=' + params[p.key])).join(', ')
       return '[indicator_activate] Mounted "' + spec.title + '" (id: ' + id + ', pane: ' + spec.pane
-        + (paramText ? ', params: ' + paramText : '') + ') on the chart. '
+        + (paramText ? ', params: ' + paramText : '')
+        + (scope !== undefined ? ', scope: ' + scope + ' (per-symbol override)' : '') + ') on the chart. '
         + 'The GUI chart renders it live via the SSE invalidation channel.'
     },
   })

--- a/packages/indicators/src/index.ts
+++ b/packages/indicators/src/index.ts
@@ -37,7 +37,10 @@ export {
   clampActivationParams,
   createMemoryChartActivationStore,
   defaultActivationInstance,
+  effectiveInstanceParams,
   resolveIndicatorSpec,
+  sanitizeInstance,
+  symbolScopeKey,
   type ChartActivationStore,
   type IndicatorSpecLike,
 } from './chart-activations.ts'

--- a/packages/indicators/src/tool.ts
+++ b/packages/indicators/src/tool.ts
@@ -1,9 +1,9 @@
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import { presetDefinitions, type IndicatorDefinition } from './presets.ts'
-import type { IndicatorParamSpec, Kline } from './types.ts'
+import type { IndicatorInstance, IndicatorParamSpec, Kline } from './types.ts'
 import type { CustomIndicatorStore } from './custom.ts'
 import type { ChartActivationStore } from './chart-activations.ts'
-import { defaultActivationInstance } from './chart-activations.ts'
+import { clampActivationParams, defaultActivationInstance } from './chart-activations.ts'
 import { validateCustomIndicatorNode } from './validate-node.ts'
 
 export { createFileCustomIndicatorStore } from './custom-fs.ts'
@@ -246,12 +246,24 @@ export function createAuthorIndicatorTool(options: AuthorIndicatorToolOptions) {
       let activatedNote = ''
       if (args.activate === true) {
         if (chartStore !== undefined) {
-          const instance = defaultActivationInstance({
+          const defaults = defaultActivationInstance({
             id: result.record.id,
             title: result.record.title,
             pane: result.record.pane,
             params: result.record.params,
           })
+          // issue #72：re-author 重挂与 indicator_activate 全局写同语义——保留已有按标的
+          // 覆盖（否则 author 一次就静默清掉覆盖）；改 schema 后按新 schema 重 clamp
+          // （旧键丢弃、缺键补默认、越界收敛），stale 覆盖不直通 compute。
+          const existing = (await chartStore.list()).find(candidate => candidate.id === result.record.id)
+          let instance: IndicatorInstance = defaults
+          if (existing?.symbolParams !== undefined) {
+            const symbolParams: Record<string, Record<string, number>> = {}
+            for (const [scope, scoped] of Object.entries(existing.symbolParams)) {
+              symbolParams[scope] = clampActivationParams(result.record.params, scoped)
+            }
+            instance = { id: defaults.id, params: defaults.params, symbolParams }
+          }
           await chartStore.activate(instance)
           onActivated?.(result.record.id)
           activatedNote = ' The indicator has also been mounted on the chart with its default parameters (see indicator_deactivate to unmount).'

--- a/packages/indicators/src/types.ts
+++ b/packages/indicators/src/types.ts
@@ -66,4 +66,10 @@ export interface IndicatorDefinition {
 export interface IndicatorInstance {
   id: string
   params: Record<string, number>
+  /**
+   * 按标的参数覆盖（issue #72）：key 为 `${market}:${symbol}`（如 "hk:00700.HK"），
+   * 命中当前标的时该套参数整体替代全局 params。锚点类自定义指标（每标的一套
+   * 锚点参数）依赖此机制；无覆盖的标的回退全局 params。
+   */
+  symbolParams?: Record<string, Record<string, number>>
 }

--- a/packages/indicators/test/chart-activations.test.ts
+++ b/packages/indicators/test/chart-activations.test.ts
@@ -252,6 +252,34 @@ describe('indicator_author「创作即上图」（issue #63）', () => {
     expect(await chartStore.list()).toEqual([{ id: 'authored_i', params: {} }])
   })
 
+  it('re-author activate:true 保留 symbolParams 并按新 schema 重 clamp（issue #72 复审：不抹覆盖、stale 覆盖不直通）', async () => {
+    const store = createMemoryCustomIndicatorStore()
+    const chartStore = createMemoryChartActivationStore()
+    const tool = createAuthorIndicatorTool({ store, chartStore })
+    const v1 = { ...AUTHOR_ARGS, paramsJson: '[{"key":"a1","label":"锚点1","default":0,"min":0,"max":20991231}]' }
+
+    // v1 挂载并写一个按标的覆盖
+    await tool.execute({ ...v1, activate: true })
+    await chartStore.activate({ id: 'authored_i', params: { a1: 0 }, symbolParams: { 'hk:00700.HK': { a1: 20240102 } } })
+
+    // v2 改 schema（a1 → a2）：重挂不清覆盖；覆盖按新 schema 重 clamp（旧键 a1 丢弃、
+    // 缺键 a2 补默认 7），全局 params 取新 schema 默认值。
+    const v2 = { ...AUTHOR_ARGS, paramsJson: '[{"key":"a2","label":"锚点2","default":7,"min":0,"max":100}]' }
+    await tool.execute({ ...v2, activate: true })
+    expect(await chartStore.list()).toEqual([{
+      id: 'authored_i', params: { a2: 7 },
+      symbolParams: { 'hk:00700.HK': { a2: 7 } },
+    }])
+
+    // v3 同 schema re-author：覆盖原样保留，全局 params 更新为新默认。
+    const v3 = { ...AUTHOR_ARGS, paramsJson: '[{"key":"a2","label":"锚点2","default":9,"min":0,"max":100}]' }
+    await tool.execute({ ...v3, activate: true })
+    expect(await chartStore.list()).toEqual([{
+      id: 'authored_i', params: { a2: 9 },
+      symbolParams: { 'hk:00700.HK': { a2: 7 } },
+    }])
+  })
+
   it('activate 缺省 → 不上图；chartStore 缺席 → 降级说明不失败', async () => {
     const store = createMemoryCustomIndicatorStore()
     const chartStore = createMemoryChartActivationStore()

--- a/packages/indicators/test/chart-activations.test.ts
+++ b/packages/indicators/test/chart-activations.test.ts
@@ -11,7 +11,10 @@ import {
   clampActivationParams,
   createMemoryChartActivationStore,
   createMemoryCustomIndicatorStore,
+  effectiveInstanceParams,
   resolveIndicatorSpec,
+  sanitizeInstance,
+  symbolScopeKey,
 } from '../src/index.js'
 import { createFileChartActivationStore } from '../src/chart-activations-fs.js'
 import { createChartActivationTools } from '../src/chart-tools.js'
@@ -76,6 +79,49 @@ describe('clampActivationParams / resolveIndicatorSpec', () => {
   })
 })
 
+describe('symbolParams 按标的参数覆盖（issue #72）', () => {
+  it('sanitizeInstance：保留合法 symbolParams，非法键/值清洗，坏形整体丢弃该字段', () => {
+    expect(sanitizeInstance({ id: 'anchor_px', params: { a1: 0 }, symbolParams: { 'hk:00700.HK': { a1: 20240102, bad: Number.NaN } } }))
+      .toEqual({ id: 'anchor_px', params: { a1: 0 }, symbolParams: { 'hk:00700.HK': { a1: 20240102 } } })
+    expect(sanitizeInstance({ id: 'anchor_px', params: { a1: 0 }, symbolParams: { '': { a1: 1 }, 'hk:x': 'nope' } }))
+      .toEqual({ id: 'anchor_px', params: { a1: 0 } })
+    expect(sanitizeInstance({ id: 'anchor_px', params: { a1: 0 } })).toEqual({ id: 'anchor_px', params: { a1: 0 } })
+    expect(sanitizeInstance({ id: '', params: {} })).toBeUndefined()
+  })
+
+  it('effectiveInstanceParams：命中覆盖整体替代，未命中/缺 market 回退全局', () => {
+    const instance = { id: 'anchor_px', params: { a1: 0 }, symbolParams: { 'hk:00700.HK': { a1: 20240102 } } }
+    expect(effectiveInstanceParams(instance, 'hk', '00700.HK')).toEqual({ a1: 20240102 })
+    expect(effectiveInstanceParams(instance, 'hk', '02714.HK')).toEqual({ a1: 0 })
+    expect(effectiveInstanceParams(instance)).toEqual({ a1: 0 })
+    expect(effectiveInstanceParams(instance, 'hk')).toEqual({ a1: 0 })
+    expect(symbolScopeKey('hk', '00700.HK')).toBe('hk:00700.HK')
+  })
+
+  it('内存 store：symbolParams 随 activate/list/replaceAll 保真深拷贝', async () => {
+    const store = createMemoryChartActivationStore()
+    const source = { a1: 20240102 }
+    await store.activate({ id: 'anchor_px', params: { a1: 0 }, symbolParams: { 'hk:00700.HK': source } })
+    source.a1 = 99999999 // 改源对象不得影响 store
+    const listed = await store.list()
+    expect(listed).toEqual([{ id: 'anchor_px', params: { a1: 0 }, symbolParams: { 'hk:00700.HK': { a1: 20240102 } } }])
+    listed[0]?.symbolParams && (listed[0].symbolParams['hk:00700.HK']!.a1 = 1) // 改读出副本不得影响 store
+    expect((await store.list())[0]?.symbolParams?.['hk:00700.HK']).toEqual({ a1: 20240102 })
+  })
+
+  it('文件 store：symbolParams 落盘读回一致', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dsh-chart-sym-'))
+    tmpDirs.push(dir)
+    const file = path.join(dir, 'chart.json')
+    const store = createFileChartActivationStore(file)
+    await store.activate({ id: 'anchor_px', params: { a1: 0 }, symbolParams: { 'hk:00700.HK': { a1: 20240102 }, 'us:GOOGL': { a1: 20240315 } } })
+    const reopened = createFileChartActivationStore(file)
+    expect(await reopened.list()).toEqual([
+      { id: 'anchor_px', params: { a1: 0 }, symbolParams: { 'hk:00700.HK': { a1: 20240102 }, 'us:GOOGL': { a1: 20240315 } } },
+    ])
+  })
+})
+
 describe('createFileChartActivationStore', () => {
   it('原子写读回一致；损坏文件降级空册', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'dsh-chart-'))
@@ -131,6 +177,42 @@ describe('图表激活工具族（indicator_list / activate / deactivate）', ()
     expect(String(await activate.execute({ id: 'td9' }))).toContain('params: count=9')
     expect(String(await activate.execute({ id: 'td9', paramsJson: '{"count":11}' }))).toContain('count=11')
     expect(await chartStore.list()).toEqual([{ id: 'td9', params: { count: 11 } }])
+  })
+
+  it('indicator_activate 按标的覆盖（issue #72）：market+symbol 写 symbolParams，全局写保留覆盖', async () => {
+    const customStore = createMemoryCustomIndicatorStore([{
+      id: 'anchor_px', title: 'AnchoredPx', pane: 'main',
+      params: [{ key: 'a1', label: '锚点1', default: 0, min: 0, max: 20991231 }],
+      computeSource: CUSTOM_SOURCE, createdAt: 1,
+    }])
+    const chartStore = createMemoryChartActivationStore()
+    const { activate } = createChartActivationTools({ customStore, chartStore })
+
+    // market/symbol 只给一个 → 业务提示，不写入
+    expect(String(await activate.execute({ id: 'anchor_px', market: 'hk' }))).toContain('supplied together')
+    expect(await chartStore.list()).toEqual([])
+
+    // 按标的写入两个覆盖，互不影响
+    const out1 = String(await activate.execute({ id: 'anchor_px', market: 'hk', symbol: '00700.HK', paramsJson: '{"a1":20240102}' }))
+    expect(out1).toContain('scope: hk:00700.HK')
+    await activate.execute({ id: 'anchor_px', market: 'us', symbol: 'GOOGL', paramsJson: '{"a1":20240315}' })
+    expect(await chartStore.list()).toEqual([{
+      id: 'anchor_px', params: { a1: 0 },
+      symbolParams: { 'hk:00700.HK': { a1: 20240102 }, 'us:GOOGL': { a1: 20240315 } },
+    }])
+
+    // 全局写：更新 params 但保留已有覆盖（回归：旧行为整体覆盖会抹掉 symbolParams）
+    await activate.execute({ id: 'anchor_px', paramsJson: '{"a1":20250110}' })
+    expect(await chartStore.list()).toEqual([{
+      id: 'anchor_px', params: { a1: 20250110 },
+      symbolParams: { 'hk:00700.HK': { a1: 20240102 }, 'us:GOOGL': { a1: 20240315 } },
+    }])
+
+    // 同标的重复写 → 覆盖该标的这套；另一标的保持
+    await activate.execute({ id: 'anchor_px', market: 'hk', symbol: '00700.HK', paramsJson: '{"a1":20240620}' })
+    expect((await chartStore.list())[0]?.symbolParams).toEqual({
+      'hk:00700.HK': { a1: 20240620 }, 'us:GOOGL': { a1: 20240315 },
+    })
   })
 
   it('indicator_deactivate：摘除后返回 removed，定义仍在库', async () => {


### PR DESCRIPTION
## 概要

Closes #72。

`IndicatorInstance` 增加可选 `symbolParams`（`"market:symbol"` → 完整参数集），命中当前标的时整体替代全局 params，无覆盖回退全局。

## 改动面

- **@dshtrading/indicators**：`sanitizeInstance`/`effectiveInstanceParams`/`symbolScopeKey` 助手；内存/文件 store 与迁移导入全链路保真 symbolParams；`indicator_activate` 工具支持 market+symbol 按标的写入（新实例全局 params 取 schema 默认值，首个覆盖不泄漏为全局值）；全局写保留已有覆盖。
- **client-ui-trading 桥**：`PUT /chart/indicators` 支持 market/symbol 作用域与 clearSymbol 清除。
- **client**：QuoteStage 按 `effectiveInstanceParams` 计算指标；参数编辑器初值 = 当前标的生效参数，已有覆盖时展示专属参数提示（新 i18n key）并写覆盖，否则写全局；chart-state/host-chart-sync 透传 scopeKey。

## 测试

- 新增：indicators 4 个 symbolParams 用例 + 工具按标的写/全局保留用例；桥端点 scope/clearSymbol/import 保真用例；chart-state scopeKey 用例。
- 门禁：`pnpm build` / `pnpm test`（1120 过 2 跳过）/ `pnpm i18n:check` 全绿。

## 决策记录

.agents/notes/implemented/feature/2026-09-07-symbol-params.md（含备选方案与后果）