### PR TITLE
feat(indicators,client-ui-trading): 指标按标的显示/隐藏（hiddenScopes）

### DIFF
--- a/.agents/notes/implemented/feature/2026-09-07-symbol-visibility.md
+++ b/.agents/notes/implemented/feature/2026-09-07-symbol-visibility.md
@@ -1,0 +1,33 @@
+# Agent Note: 指标按标的显示/隐藏（symbol visibility）
+
+Status: implemented
+
+## Problem
+
+激活名册的指标开关是全局联动的（issue #63 模型）：在一个标的上开启某指标，切到任何标的它都开启。有些自定义指标只适用于特定市场/标的（如自定义「K大师」只适合港股与 A 股，对美股/加密不合适），需要按标的独立开关显示。
+
+## Decision
+
+`IndicatorInstance` 增加可选 `hiddenScopes?: string[]`——隐藏作用域键两级：「market」（整市场，如 `"us"`）与「`${market}:${symbol}`」（单标的）。命中任一作用域即对该标的隐藏；无隐藏记录 = 跟随全局激活（默认可见），存量名册零迁移。**隐藏 ≠ 取消激活**：实例仍在名册（每 id 单实例 SSOT 不变），只影响渲染。
+
+- 共享助手（@dshtrading/indicators）：`isInstanceVisibleOn(instance, market?, symbol?)` 读侧判定；`withHiddenScopes(instance, scope, visible)` 纯函数切换（幂等，清空后字段整体消失）；`sanitizeInstance` 扩展清洗 hiddenScopes（非空串去重，坏值整字段丢弃），内存/文件 store 与迁移导入全链路保真。
+- 写入边界：
+  - GUI 复选框/快捷词条 = 当前标的开关：关→记隐藏；开→清隐藏；未挂载→全局挂载；无聚焦标的退回全局开关（旧语义）。共享 handler `toggleIndicatorVisible`，QuoteStage 内 `visibleInstances` memo 是唯一过滤点（图表调度/读数行/发 Agent 快照标题与读数/快捷词条/勾选态全部消费它）。
+  - GUI 行内「全局移除」按钮（带确认）= 原 togglePreset 全局卸载语义，保留「关掉所有标的」入口。
+  - `indicator_activate(id, market, symbol)` = #72 写参数覆盖语义 + 清除该标的两级隐藏（显示 + 写覆盖）。
+  - `indicator_deactivate(id, market, symbol?)` = scope 隐藏（market 级 / symbol 级），实例缺席 no-op 不反向创建；无 scope 仍为全局卸载。
+  - 桥 `PUT /chart/indicators` 新增 `visible:boolean`：仅 market 即整市场、market+symbol 即单标的；实例缺席幂等 no-op；visible 缺 market 业务拒绝；不带 visible 时维持 #72 行为（params 覆盖/clearSymbol/全局写，半参仍 `TRADING_INVALID_SCOPE`）。
+- 同步链：chart-state 新方法 `setSymbolVisibility(id, market, symbol, visible)`（GUI 只写 symbol 级），host-chart-sync host-first 接管（PUT visible → 成功才改本地镜像）；桥 PUT 成功/工具 onWritten 走既有 emit('chart')，零新增 SSE 接线。
+
+## Alternatives considered
+
+- **按标的独立激活名册**（每标的一份挂载清单）：切换语义直白，但破坏「每 id 单实例」SSOT（参数覆盖、编辑器、instanceKey 都假设单实例），新标的默认名册语义不明，全局开/关与按标的开/关互相打架。否决。
+- **仅单标的粒度**：模型最简，但「只适用于港 A」类指标要在每个美股/加密标的上逐个手动关一次，与其动机（市场级不适用）不匹配。加 market 级后 agent 一条 `indicator_deactivate(id, market:'us')` 即可。
+- **复选框渐变语义**（首次关=全局卸载，已有隐藏表后=按标的）：省一个按钮，但「保留港 A、只关美加」无法表达（首次关就全局没了）。否决，改为复选框专职按标的 + 行内显式「全局移除」。
+
+## Consequences
+
+- 预置与自定义指标均可按标的隐藏；`indicator_list` 的 active 名册自动带出 hiddenScopes（agent 可读当前隐藏状态）。
+- GUI 复选框语义从「全局开关」变为「当前标的开关」——旧全局关路径收敛到行内「全局移除」按钮与 `indicator_deactivate`（无 scope）。
+- 隐藏的实例仍占名册与 localStorage/host 存储；「显示但参数不适用」由 symbolParams（#72）与 hiddenScopes 正交组合表达。
+- 测试：indicators 包 hiddenScopes sanitize/可见性助手/withHiddenScopes/store 保真 + deactivate 三种 scope 形态 + activate 清隐藏；client-ui-trading 桥 visible 写入（symbol/market 级、缺席 no-op、缺 market 拒绝）、import 保真、chart-state setSymbolVisibility。门禁 pnpm build / pnpm test / i18n:check 全绿。

--- a/packages/client-ui-trading/src/bridge.ts
+++ b/packages/client-ui-trading/src/bridge.ts
@@ -20,7 +20,7 @@ import { aggregateNews as aggregateHkNews, fetchHkFundamentalsPackage } from '@d
 import { aggregateNews as aggregateUsNews, fetchUsFundamentalsPackage } from '@dshtrading/kit-us'
 import { aggregateNews as aggregateCryptoNews, fetchCryptoFundamentalsPackage } from '@dshtrading/kit-crypto'
 import type { ChartActivationStore, CustomIndicatorRecord, CustomIndicatorStore, IndicatorInstance } from '@dshtrading/indicators'
-import { clampActivationParams, createMemoryChartActivationStore, createMemoryCustomIndicatorStore, resolveIndicatorSpec, sanitizeInstance, symbolScopeKey } from '@dshtrading/indicators'
+import { clampActivationParams, createMemoryChartActivationStore, createMemoryCustomIndicatorStore, resolveIndicatorSpec, sanitizeInstance, symbolScopeKey, withHiddenScopes } from '@dshtrading/indicators'
 import type { KnowledgeCard, KnowledgeCardStore } from '@dshtrading/knowledge'
 import { createMemoryKnowledgeCardStore } from '@dshtrading/knowledge'
 import type { CustomStrategyRecord, CustomStrategyStore } from '@dshtrading/strategies'
@@ -1151,17 +1151,20 @@ export class TradingBridge {
   }
 
   /**
-   * 挂载/更新一个激活实例（PUT /chart/indicators，body { id, params?, market?, symbol?, clearSymbol? }）：
+   * 挂载/更新一个激活实例（PUT /chart/indicators，body { id, params?, market?, symbol?, clearSymbol?, visible? }）：
    * id 必须能解析为预置或自定义指标（未知 id 业务拒绝——与 GUI 可渲染集合同源）；
    * params 按 schema clamp，缺失键取 schema 默认值。
    * issue #72：body 同时带 market+symbol 时写入该标的的参数覆盖（symbolParams[
    * `${market}:${symbol}`]），clearSymbol:true 改为删除该覆盖；不带 scope 时写
    * 全局 params。两种写法都保留实例上已有的其他覆盖。market/symbol 只给其一是
    * 业务拒绝（TRADING_INVALID_SCOPE）；clearSymbol 对未挂载 id 是无操作不建实例。
+   * symbol visibility：body 带 visible:boolean 时为可见性写——仅 market 即整市场
+   * 隐藏/显示，market+symbol 为单标的；实例缺席为幂等 no-op 不反向创建；visible
+   * 优先于 params/clearSymbol（同请求带 params 时被忽略）。
    */
   async putChartActivation(body: unknown): Promise<ChartActivationsWire | ChartActivationRejectedWire> {
     const store = this.host.chartActivationsStore
-    const raw = (body ?? {}) as { id?: unknown; params?: unknown; market?: unknown; symbol?: unknown; clearSymbol?: unknown }
+    const raw = (body ?? {}) as { id?: unknown; params?: unknown; market?: unknown; symbol?: unknown; clearSymbol?: unknown; visible?: unknown }
     const id = typeof raw.id === 'string' ? raw.id.trim() : ''
     if (!id) throw new BridgeProtocolError(400, 'chart activation body requires string id')
     const spec = await resolveIndicatorSpec(id, this.host.customIndicatorsStore)
@@ -1181,10 +1184,12 @@ export class TradingBridge {
     const params = clampActivationParams(spec.params, overrides)
     const market = typeof raw.market === 'string' ? raw.market.trim() : ''
     const symbol = typeof raw.symbol === 'string' ? raw.symbol.trim() : ''
+    const hasVisible = typeof raw.visible === 'boolean'
     const scope = market !== '' && symbol !== '' ? symbolScopeKey(market, symbol) : undefined
-    if (scope === undefined && (market !== '' || symbol !== '')) {
-      // 与 indicator_activate 工具同规则：scope 只收成对 market+symbol，
-      // 半参业务拒绝而非静默落全局（全局写影响所有标的）。
+    if (scope === undefined && !hasVisible && (market !== '' || symbol !== '')) {
+      // 与 indicator_activate 工具同规则：params 覆盖只收成对 market+symbol，
+      // 半参业务拒绝而非静默落全局（全局写影响所有标的）。可见性写例外：仅
+      // market 合法（整市场隐藏/显示）。
       return {
         ok: false,
         code: 'TRADING_INVALID_SCOPE',
@@ -1193,6 +1198,20 @@ export class TradingBridge {
       }
     }
     const existing = store !== undefined ? (await store.list()).find(instance => instance.id === id) : undefined
+
+    if (hasVisible) {
+      // 可见性写：实例缺席为幂等 no-op（隐藏未挂载指标无意义，不反向创建）。
+      if (market === '') {
+        return { ok: false, code: 'TRADING_INVALID_SCOPE', message: 'visibility write requires market (optionally symbol)' }
+      }
+      if (existing === undefined) {
+        return { ok: true, instances: store !== undefined ? await store.list() : [] }
+      }
+      const hideScope = symbol !== '' ? symbolScopeKey(market, symbol) : market
+      const next = withHiddenScopes(existing, hideScope, raw.visible === true)
+      if (next !== existing) await store.activate(next)
+      return { ok: true, instances: store !== undefined ? await store.list() : [next] }
+    }
 
     let instance: IndicatorInstance
     if (scope !== undefined) {
@@ -1329,8 +1348,13 @@ function parseChartInstances(body: unknown): IndicatorInstance[] {
     for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
       if (typeof value === 'number' && Number.isFinite(value)) clean[key] = value
     }
-    // 行保留语义不变（脏值清洗成空 params），symbolParams 经 sanitizeInstance 保真（issue #72）。
-    const normalized = sanitizeInstance({ id, params: clean, symbolParams: (item as { symbolParams?: unknown }).symbolParams })
+    // 行保留语义不变（脏值清洗成空 params），symbolParams/hiddenScopes 经 sanitizeInstance 保真（issue #72 / symbol visibility）。
+    const normalized = sanitizeInstance({
+      id,
+      params: clean,
+      symbolParams: (item as { symbolParams?: unknown }).symbolParams,
+      hiddenScopes: (item as { hiddenScopes?: unknown }).hiddenScopes,
+    })
     if (normalized !== undefined) out.push(normalized)
   }
   return out

--- a/packages/client-ui-trading/src/client/MiddleStage.tsx
+++ b/packages/client-ui-trading/src/client/MiddleStage.tsx
@@ -51,6 +51,10 @@ export interface MiddleStageInjected {
   }
   toggleIndicator: (id: string) => void
   setIndicatorParams: (id: string, params: Record<string, number>, scopeKey?: string) => void
+  /** 按标的可见性（symbol visibility；scopeKey = `${market}:${symbol}`，缺省忽略）。 */
+  setIndicatorVisible: (id: string, visible: boolean, scopeKey?: string) => void
+  /** 全局移除：卸载所有标的上的该指标实例。 */
+  removeIndicator: (id: string) => void
   /** 删除自定义指标（issue #30，透传给 QuoteStage 指标选择器）。 */
   deleteIndicator: (id: string) => Promise<boolean>
   /** 行情上下文 → 会话输入框（透传给 QuoteStage「发给 Agent」，只填入不发送）。 */
@@ -62,7 +66,7 @@ export type MiddleStageProps =
   & PropsLocale<'dshtrading.market'>
   & InjectFace<MiddleStageInjected>
 
-export function MiddleStage({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, deleteIndicator, fillComposer }: MiddleStageProps) {
+export function MiddleStage({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, setIndicatorVisible, removeIndicator, deleteIndicator, fillComposer }: MiddleStageProps) {
   // 名册响应式：registry 版本号驱动 tab 条重渲染；当前视图是普通 state
   // （readStageView 净化 localStorage 脏值）。
   useSyncExternalStore(stageViews.subscribe, stageViews.getVersion)
@@ -95,7 +99,7 @@ export function MiddleStage({ t, useSelection, useChart, toggleIndicator, setInd
           quote 视图 = shell 内建（QuoteStage 直引——需要中栏全部指标动作面）；
           插件视图走 definition.render(props)。 */}
       {view === 'quote' ? (
-        <QuoteStage {...({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, deleteIndicator, fillComposer } as never)} />
+        <QuoteStage {...({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, setIndicatorVisible, removeIndicator, deleteIndicator, fillComposer } as never)} />
       ) : (
         (() => {
           const definition = stageViews.get(view)

--- a/packages/client-ui-trading/src/client/QuotePane.tsx
+++ b/packages/client-ui-trading/src/client/QuotePane.tsx
@@ -28,6 +28,10 @@ export interface QuotePaneInjected {
   }
   toggleIndicator: (id: string) => void
   setIndicatorParams: (id: string, params: Record<string, number>, scopeKey?: string) => void
+  /** 按标的可见性（symbol visibility；scopeKey = `${market}:${symbol}`，缺省忽略）。 */
+  setIndicatorVisible: (id: string, visible: boolean, scopeKey?: string) => void
+  /** 全局移除：卸载所有标的上的该指标实例。 */
+  removeIndicator: (id: string) => void
   /** 删除自定义指标（issue #30）：桥 DELETE → 注销注册表 + 移除激活实例。 */
   deleteIndicator: (id: string) => Promise<boolean>
   /** 行情上下文 → 会话输入框（只填入不发送；shell 注入）。 */
@@ -46,7 +50,7 @@ interface Rect {
   height: number
 }
 
-export function QuotePane({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, deleteIndicator, fillComposer }: QuotePaneProps) {
+export function QuotePane({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, setIndicatorVisible, removeIndicator, deleteIndicator, fillComposer }: QuotePaneProps) {
   const [rect, setRect] = useState<Rect | null>(null)
 
   useEffect(() => {
@@ -140,7 +144,7 @@ export function QuotePane({ t, useSelection, useChart, toggleIndicator, setIndic
     >
       {/* MiddleStage 的 slot 运行时面（viewRequest 等）在面板场景不需要，
           只取 t/两个 store hook 与指标动作。 */}
-      <MiddleStage {...({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, deleteIndicator, fillComposer } as never)} />
+      <MiddleStage {...({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, setIndicatorVisible, removeIndicator, deleteIndicator, fillComposer } as never)} />
     </div>
   )
 }

--- a/packages/client-ui-trading/src/client/QuoteStage.tsx
+++ b/packages/client-ui-trading/src/client/QuoteStage.tsx
@@ -33,7 +33,7 @@ import {
 } from './format.ts'
 import { indicators, isCustomIndicator } from './indicator-registry.ts'
 import type { IndicatorDefinition, IndicatorInstance } from '@dshtrading/indicators'
-import { effectiveInstanceParams, symbolScopeKey } from '@dshtrading/indicators'
+import { effectiveInstanceParams, isInstanceVisibleOn, symbolScopeKey } from '@dshtrading/indicators'
 import { MARKET_INTERVALS } from './store.ts'
 import type { SelectionState } from './store.ts'
 import type { ChartState } from './chart-state.ts'
@@ -102,6 +102,14 @@ export interface QuoteStageProps {
   useChart: UseStoreState<ChartState>
   toggleIndicator: (id: string) => void
   setIndicatorParams: (id: string, params: Record<string, number>, scopeKey?: string) => void
+  /**
+   * 按标的可见性（symbol visibility）：visible=false 记隐藏、true 清该标的隐藏。
+   * scopeKey = `${market}:${symbol}`；缺省（无聚焦标的）由 shell 忽略——调用方
+   * 在该情形应退回 toggleIndicator 全局语义。
+   */
+  setIndicatorVisible: (id: string, visible: boolean, scopeKey?: string) => void
+  /** 全局移除：卸载所有标的上的该指标实例（原 togglePreset 全局关语义）。 */
+  removeIndicator: (id: string) => void
   /** 删除自定义指标（issue #30 删除入口；仅自定义行渲染按钮）。 */
   deleteIndicator: (id: string) => Promise<boolean>
   /** 行情上下文 → 会话输入框（只填入不发送；shell 注入，缺席时按钮不渲染）。 */
@@ -122,7 +130,7 @@ type SendState = 'idle' | 'sending' | 'sent' | 'error'
 /** 信号 reason 的币种符号（按市场；crypto 以 USD 计价近似）。 */
 const CURRENCY_SYMBOL: Record<MarketId, string> = { cn: '¥', hk: 'HK$', us: '$', crypto: '$' }
 
-export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, deleteIndicator, fillComposer }: QuoteStageProps) {
+export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndicatorParams, setIndicatorVisible, removeIndicator, deleteIndicator, fillComposer }: QuoteStageProps) {
   const instrument = useSelection(value => value.instrument)
   const market: MarketId | undefined = (instrument?.market && ['crypto', 'us', 'cn', 'hk'].includes(instrument.market))
     ? (instrument.market as MarketId)
@@ -135,6 +143,27 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
   const numLocale = scaleLocaleOf(t)
 
   const instances = useChart(state => state.instances)
+  // symbol visibility：按标的可见实例——唯一过滤点。图表调度、读数行、发 Agent
+  // 快照（标题/读数）、快捷词条、选择器勾选态全部消费它（隐藏 ≠ 取消激活，
+  // 实例仍在名册，raw `instances` 仅供「全局移除」按钮判定存在性）。
+  const visibleInstances = useMemo(
+    () => instances.filter(instance => isInstanceVisibleOn(instance, market, symbol)),
+    [instances, market, symbol],
+  )
+  // 复选框/快捷词条共用的按标的开关（symbol visibility）：关→记隐藏；开→清隐藏；
+  // 未挂载→全局挂载；无聚焦标的（market/symbol 缺失）退回全局开关语义。
+  const toggleIndicatorVisible = (id: string): void => {
+    const raw = instances.find(candidate => candidate.id === id)
+    const isVisible = raw !== undefined && isInstanceVisibleOn(raw, market, symbol)
+    if (market === undefined || symbol === undefined) {
+      toggleIndicator(id)
+      return
+    }
+    const scopeKey = symbolScopeKey(market, symbol)
+    if (isVisible) setIndicatorVisible(id, false, scopeKey)
+    else if (raw !== undefined) setIndicatorVisible(id, true, scopeKey)
+    else toggleIndicator(id)
+  }
   // 指标名册修订号：插件晚于首帧合并 definition 时触发重渲染。
   const rosterVersion = useSyncExternalStore(indicators.subscribe, indicators.getVersion)
 
@@ -576,11 +605,11 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
     [rangeSelection, klines],
   )
 
-  // 指标调度：klines × 激活实例 → 渲染输入
+  // 指标调度：可见实例 × klines → 渲染输入（symbol visibility 过滤后的实例才参与）
   const indicatorGroups = useMemo(() => {
     if (klines === null) return []
     const groups: Array<TvIndicatorGroup & { id: string; pane: 'main' | 'sub'; title: string }> = []
-    for (const instance of instances) {
+    for (const instance of visibleInstances) {
       const definition = indicators.get(instance.id)
       if (definition === undefined) continue
       groups.push({
@@ -594,7 +623,7 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
       })
     }
     return groups
-  }, [klines, instances, rosterVersion, market, symbol])
+  }, [klines, visibleInstances, rosterVersion, market, symbol])
 
   const mainOverlays = useMemo(() => indicatorGroups.filter(group => group.pane === 'main'), [indicatorGroups])
   const subIndicators = useMemo(() => indicatorGroups.filter(group => group.pane === 'sub'), [indicatorGroups])
@@ -724,7 +753,7 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
       pct: stats.pct,
       prevClose: stats.prevClose,
       candle: readoutCandle,
-      indicatorTitles: instances.map(instance => indicators.get(instance.id)?.title ?? instance.id),
+      indicatorTitles: visibleInstances.map(instance => indicators.get(instance.id)?.title ?? instance.id),
       withScreenshot: capture !== null,
     }
     // exactOptionalPropertyTypes：undefined 字段直接剔除而非显式传 undefined。
@@ -1087,21 +1116,26 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
               {pickerOpen && (
                 <IndicatorPicker
                   t={t}
-                  instances={instances}
+                  instances={visibleInstances}
+                  activeInstances={instances}
                   editingIndicator={editingIndicator}
                   scopeKey={market !== undefined && symbol !== undefined ? symbolScopeKey(market, symbol) : undefined}
                   symbolLabel={symbol}
                   onToggle={(id) => {
-                    toggleIndicator(id)
+                    toggleIndicatorVisible(id)
                     setEditingIndicator(null)
                   }}
                   onEdit={(id) => { setEditingIndicator(current => current === id ? null : id) }}
                   onApply={(id, params) => {
                     // issue #72：当前标的已有参数覆盖 → 写覆盖；否则写全局 params。
                     const scopeKey = market !== undefined && symbol !== undefined ? symbolScopeKey(market, symbol) : undefined
-                    const instance = instances.find(candidate => candidate.id === id)
+                    const instance = visibleInstances.find(candidate => candidate.id === id)
                     const hasOverride = scopeKey !== undefined && instance?.symbolParams?.[scopeKey] !== undefined
                     setIndicatorParams(id, params, hasOverride ? scopeKey : undefined)
+                    setEditingIndicator(null)
+                  }}
+                  onRemoveGlobal={(id) => {
+                    removeIndicator(id)
                     setEditingIndicator(null)
                   }}
                   onDelete={(id) => { void deleteIndicator(id) }}
@@ -1312,14 +1346,14 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
       {stageTab === 'chart' && (
         <div className={css.quickIndicatorBar} role="toolbar" aria-label="Quick indicators">
           {allDefinitions.map(def => {
-            const active = instances.some(inst => inst.id === def.id)
+            const active = visibleInstances.some(inst => inst.id === def.id)
             return (
               <button
                 key={def.id}
                 type="button"
                 className={css.quickIndicatorTag}
                 data-active={active ? 'true' : undefined}
-                onClick={() => toggleIndicator(def.id)}
+                onClick={() => toggleIndicatorVisible(def.id)}
                 title={`${def.title} (${def.pane === 'main' ? t('indicator.group.main') : t('indicator.group.sub')})`}
               >
                 {def.title}
@@ -1362,7 +1396,10 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
 
 function IndicatorPicker(props: {
   t: Translate
+  /** 当前标的可见实例（勾选态/参数编辑的数据源）。 */
   instances: IndicatorInstance[]
+  /** 全量激活名册（含对当前标的隐藏的实例）——「全局移除」按钮的存在性判定。 */
+  activeInstances: IndicatorInstance[]
   editingIndicator: string | null
   /** 当前标的的 scope 键（`${market}:${symbol}`）；undefined = 无聚焦标的。 */
   scopeKey?: string | undefined
@@ -1371,10 +1408,11 @@ function IndicatorPicker(props: {
   onToggle: (id: string) => void
   onEdit: (id: string) => void
   onApply: (id: string, params: Record<string, number>) => void
+  onRemoveGlobal: (id: string) => void
   onDelete: (id: string) => void
   onClose: () => void
 }): React.JSX.Element {
-  const { t, instances, editingIndicator, scopeKey, symbolLabel, onToggle, onEdit, onApply, onDelete, onClose } = props
+  const { t, instances, activeInstances, editingIndicator, scopeKey, symbolLabel, onToggle, onEdit, onApply, onRemoveGlobal, onDelete, onClose } = props
   const definitions = indicators.list()
   const empty = definitions.length === 0
   return (
@@ -1390,6 +1428,7 @@ function IndicatorPicker(props: {
               title={t('indicator.group.main')}
               definitions={definitions.filter(definition => definition.pane === 'main')}
               instances={instances}
+              activeInstances={activeInstances}
               editingIndicator={editingIndicator}
               scopeKey={scopeKey}
               symbolLabel={symbolLabel}
@@ -1397,12 +1436,14 @@ function IndicatorPicker(props: {
               onToggle={onToggle}
               onEdit={onEdit}
               onApply={onApply}
+              onRemoveGlobal={onRemoveGlobal}
               onDelete={onDelete}
             />
             <PickerGroup
               title={t('indicator.group.sub')}
               definitions={definitions.filter(definition => definition.pane === 'sub')}
               instances={instances}
+              activeInstances={activeInstances}
               editingIndicator={editingIndicator}
               scopeKey={scopeKey}
               symbolLabel={symbolLabel}
@@ -1410,6 +1451,7 @@ function IndicatorPicker(props: {
               onToggle={onToggle}
               onEdit={onEdit}
               onApply={onApply}
+              onRemoveGlobal={onRemoveGlobal}
               onDelete={onDelete}
             />
           </>
@@ -1422,7 +1464,10 @@ function IndicatorPicker(props: {
 function PickerGroup(props: {
   title: string
   definitions: readonly IndicatorDefinition[]
+  /** 当前标的可见实例（勾选态/参数编辑）。 */
   instances: readonly IndicatorInstance[]
+  /** 全量激活名册（「全局移除」按钮存在性）。 */
+  activeInstances: readonly IndicatorInstance[]
   editingIndicator: string | null
   scopeKey?: string | undefined
   symbolLabel?: string | undefined
@@ -1430,28 +1475,30 @@ function PickerGroup(props: {
   onToggle: (id: string) => void
   onEdit: (id: string) => void
   onApply: (id: string, params: Record<string, number>) => void
+  onRemoveGlobal: (id: string) => void
   onDelete: (id: string) => void
 }): React.JSX.Element {
-  const { title, definitions, instances, editingIndicator, scopeKey, symbolLabel, t, onToggle, onEdit, onApply, onDelete } = props
+  const { title, definitions, instances, activeInstances, editingIndicator, scopeKey, symbolLabel, t, onToggle, onEdit, onApply, onRemoveGlobal, onDelete } = props
   return (
     <div className={css.pickerGroup}>
       <div className={css.pickerGroupTitle}>{title}</div>
       {definitions.map(definition => {
-        const instance = instances.find(candidate => candidate.id === definition.id) ?? null
+        const visible = instances.find(candidate => candidate.id === definition.id) ?? null
+        const active = activeInstances.some(candidate => candidate.id === definition.id)
         const editing = editingIndicator === definition.id
         // issue #72：编辑器初值 = 当前标的生效参数（覆盖优先），有覆盖时展示提示。
-        const scopedParams = instance !== null && scopeKey !== undefined ? instance.symbolParams?.[scopeKey] : undefined
+        const scopedParams = visible !== null && scopeKey !== undefined ? visible.symbolParams?.[scopeKey] : undefined
         return (
           <div key={definition.id} className={css.pickerRow}>
             <label className={css.pickerLabel}>
               <input
                 type="checkbox"
-                checked={instance !== null}
+                checked={visible !== null}
                 onChange={() => onToggle(definition.id)}
               />
               <span>{definition.title}</span>
             </label>
-            {instance !== null && (
+            {visible !== null && (
               <button
                 type="button"
                 className={css.pickerParams}
@@ -1459,6 +1506,19 @@ function PickerGroup(props: {
                 onClick={() => onEdit(definition.id)}
               >
                 {t('indicator.params')}
+              </button>
+            )}
+            {active && (
+              <button
+                type="button"
+                className={css.pickerParams}
+                title={t('indicator.removeGlobal')}
+                aria-label={t('indicator.removeGlobal')}
+                onClick={() => {
+                  if (window.confirm(t('indicator.removeGlobalConfirm'))) onRemoveGlobal(definition.id)
+                }}
+              >
+                {t('indicator.removeGlobal')}
               </button>
             )}
             {isCustomIndicator(definition.id) && (
@@ -1474,10 +1534,10 @@ function PickerGroup(props: {
                 {t('indicator.delete')}
               </button>
             )}
-            {editing && instance !== null && (
+            {editing && visible !== null && (
               <IndicatorParamEditor
                 definition={definition}
-                initial={scopedParams ?? instance.params}
+                initial={scopedParams ?? visible.params}
                 overrideHint={scopedParams !== undefined && symbolLabel !== undefined
                   ? t('indicator.symbolOverride', { symbol: symbolLabel })
                   : undefined}

--- a/packages/client-ui-trading/src/client/api.ts
+++ b/packages/client-ui-trading/src/client/api.ts
@@ -450,11 +450,13 @@ export async function fetchChartActivations(): Promise<IndicatorInstance[]> {
 /**
  * 挂载/更新一个激活实例（PUT /chart/indicators；未知 id → ok:false，转 false）。
  * issue #72：带 scope（market+symbol）时写该标的的参数覆盖，不动全局 params。
+ * symbol visibility：scope 带 visible 时为可见性写（market 必带，symbol 可选——
+ * 缺省即整市场），params 缺省。
  */
 export async function putChartActivation(
   id: string,
   params?: Record<string, number>,
-  scope?: { market: string; symbol: string },
+  scope?: { market: string; symbol?: string; visible?: boolean },
 ): Promise<boolean> {
   try {
     const response = await fetch('/dshtrading/api/chart/indicators', {
@@ -463,7 +465,11 @@ export async function putChartActivation(
       body: JSON.stringify({
         id,
         ...(params !== undefined ? { params } : {}),
-        ...(scope !== undefined ? { market: scope.market, symbol: scope.symbol } : {}),
+        ...(scope !== undefined ? {
+          market: scope.market,
+          ...(scope.symbol !== undefined ? { symbol: scope.symbol } : {}),
+          ...(scope.visible !== undefined ? { visible: scope.visible } : {}),
+        } : {}),
       }),
     })
     if (!response.ok) return false

--- a/packages/client-ui-trading/src/client/chart-state.ts
+++ b/packages/client-ui-trading/src/client/chart-state.ts
@@ -10,6 +10,7 @@
  * 该 id 的可点行，此分支 UI 不可达，防御手改 localStorage）。
  */
 import type { IndicatorInstance, IndicatorRegistry } from '@dshtrading/indicators'
+import { symbolScopeKey, withHiddenScopes } from '@dshtrading/indicators'
 import { createObservable, readJson, writeJson } from './store.ts'
 import type { WritableObservable } from './store.ts'
 
@@ -28,6 +29,11 @@ export interface ChartStateStore extends WritableObservable<ChartState> {
    * 全局 params 与其它标的覆盖保持不变；不带 scopeKey 写全局 params 并保留覆盖表。
    */
   setParams(id: string, params: Record<string, number>, scopeKey?: string): void
+  /**
+   * 按标的可见性（GUI 复选框，symbol 级）：visible=false 记隐藏、true 清隐藏；
+   * 实例缺席静默（挂载走 togglePreset）。隐藏 ≠ 取消激活，其它标的不受影响。
+   */
+  setSymbolVisibility(id: string, market: string, symbol: string, visible: boolean): void
   /** 移除某 preset 的激活实例（自定义指标删除用；无实例时静默）。 */
   removeInstance(id: string): void
   instanceFor(id: string): IndicatorInstance | undefined
@@ -80,6 +86,16 @@ export function createChartStateStore(registry: IndicatorRegistry): ChartStateSt
     },
     removeInstance(id) {
       store.update((current) => ({ instances: current.instances.filter(instance => instance.id !== id) }))
+      persist()
+    },
+    setSymbolVisibility(id, market, symbol, visible) {
+      store.update((current) => {
+        const existing = current.instances.find(instance => instance.id === id)
+        if (existing === undefined) return current
+        const next = withHiddenScopes(existing, symbolScopeKey(market, symbol), visible)
+        if (next === existing) return current
+        return { instances: current.instances.map(instance => instance.id === id ? next : instance) }
+      })
       persist()
     },
     instanceFor(id) {

--- a/packages/client-ui-trading/src/client/contract.ts
+++ b/packages/client-ui-trading/src/client/contract.ts
@@ -513,6 +513,8 @@ export type MarketLocaleKey =
   | 'indicator.apply'
   | 'indicator.cancel'
   | 'indicator.symbolOverride'
+  | 'indicator.removeGlobal'
+  | 'indicator.removeGlobalConfirm'
   | 'indicator.delete'
   | 'indicator.deleteConfirm'
   | 'interval.1m'

--- a/packages/client-ui-trading/src/client/host-chart-sync.ts
+++ b/packages/client-ui-trading/src/client/host-chart-sync.ts
@@ -4,8 +4,8 @@
  * - 启动同步：GET /chart/indicators → host 有行则以 host 为准覆盖本地 observable；
  *   host 为空且本地 localStorage 有存量 → 一次性迁移导入（POST /chart/indicators/import，
  *   host 非空时服务端拒绝，幂等）→ 重拉 host。
- * - 变更 host-first：togglePreset / setParams / removeInstance 先写 host，成功后才
- *   更新本地 observable（localStorage 由原 store 持久化，降级为缓存镜像）。
+ * - 变更 host-first：togglePreset / setParams / setSymbolVisibility / removeInstance
+ *   先写 host，成功后才更新本地 observable（localStorage 由原 store 持久化，降级为缓存镜像）。
  * - SSE：'chart' 失效信号 → 重拉 host 覆盖本地（indicator_activate/deactivate 工具
  *   写入、indicators/plugin emit 或其它标签页变更）。
  *
@@ -90,6 +90,15 @@ export function wireHostChartSync(options: HostChartSyncOptions): () => void {
       const ok = await putChartActivation(id, params, scope)
       if (ok) originalSetParams(id, params, scopeKey)
       else console.warn('[dsh-trading] chart param update failed on host — local state unchanged')
+    })()
+  }
+  const originalSetSymbolVisibility = chart.setSymbolVisibility.bind(chart)
+  chart.setSymbolVisibility = (id: string, market: string, symbol: string, visible: boolean): void => {
+    void (async () => {
+      // symbol visibility：GUI 只写 symbol 级（整市场隐藏走工具/桥）。
+      const ok = await putChartActivation(id, undefined, { market, symbol, visible })
+      if (ok) originalSetSymbolVisibility(id, market, symbol, visible)
+      else console.warn('[dsh-trading] chart visibility update failed on host — local state unchanged')
     })()
   }
   const originalRemove = chart.removeInstance.bind(chart)

--- a/packages/client-ui-trading/src/client/index.ts
+++ b/packages/client-ui-trading/src/client/index.ts
@@ -282,6 +282,14 @@ export function apply(ctx: ClientContext): void {
       hooks: { selection, chart },
       toggleIndicator: (id) => { chart.togglePreset(id) },
       setIndicatorParams: (id, params, scopeKey) => { chart.setParams(id, params, scopeKey) },
+      // symbol visibility：scopeKey = "<market>:<symbol>"；缺省（无聚焦标的）忽略——
+      // QuoteStage 在该情形走 toggleIndicator 全局语义。
+      setIndicatorVisible: (id, visible, scopeKey) => {
+        const split = scopeKey !== undefined ? scopeKey.indexOf(':') : -1
+        if (scopeKey === undefined || split <= 0) return
+        chart.setSymbolVisibility(id, scopeKey.slice(0, split), scopeKey.slice(split + 1), visible)
+      },
+      removeIndicator: (id) => { if (chart.isActive(id)) chart.togglePreset(id) },
       deleteIndicator: async (id) => {
         const ok = await deleteCustomIndicator(id)
         if (ok) {

--- a/packages/client-ui-trading/src/client/locales.ts
+++ b/packages/client-ui-trading/src/client/locales.ts
@@ -606,6 +606,8 @@ export const zh: Record<MarketLocaleKey, string> = {
       'indicator.delete': '删除',
       'indicator.deleteConfirm': '确定删除该自定义指标？已持久化的定义将从指标库移除。',
       'indicator.symbolOverride': '当前为 {symbol} 的专属参数（仅对该标的生效）',
+      'indicator.removeGlobal': '全局移除',
+      'indicator.removeGlobalConfirm': '确定卸载所有标的上的该指标？（复选框仅控制当前标的的显示）',
 }
 
 export const en: Record<MarketLocaleKey, string> = {
@@ -1207,4 +1209,6 @@ export const en: Record<MarketLocaleKey, string> = {
       'indicator.delete': 'Delete',
       'indicator.deleteConfirm': 'Delete this custom indicator? The persisted definition will be removed from the library.',
       'indicator.symbolOverride': 'Editing symbol-specific params for {symbol} (applies to this instrument only)',
+      'indicator.removeGlobal': 'Remove everywhere',
+      'indicator.removeGlobalConfirm': 'Unmount this indicator on every symbol? (The checkbox only toggles the current symbol.)',
 }

--- a/packages/client-ui-trading/test/chart-activations.test.ts
+++ b/packages/client-ui-trading/test/chart-activations.test.ts
@@ -140,6 +140,54 @@ describe('图表激活名册桥端点（issue #63）', () => {
     expect(list).toEqual({ status: 200, payload: { ok: true, instances: [] } })
   })
 
+  it('PUT visible 可见性写：symbol 级/market 级隐藏与显示；缺席 no-op；缺 market 拒绝（symbol visibility）', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), { id: 'td9', params: { count: 9 } })
+
+    // 单标的隐藏
+    const wire = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'td9', market: 'us', symbol: 'GOOGL', visible: false })
+    expect(wire).toEqual({
+      status: 200,
+      payload: { ok: true, instances: [{ id: 'td9', params: { count: 9 }, hiddenScopes: ['us:GOOGL'] }] },
+    })
+
+    // 整市场隐藏追加 → 再显示单标的只清 symbol 级
+    await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(), { id: 'td9', market: 'hk', visible: false })
+    await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'td9', market: 'us', symbol: 'GOOGL', visible: true })
+    const list = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(list).toEqual({
+      status: 200,
+      payload: { ok: true, instances: [{ id: 'td9', params: { count: 9 }, hiddenScopes: ['hk'] }] },
+    })
+
+    // 实例缺席：幂等 no-op 不反向创建
+    const ghost = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'ma', market: 'us', symbol: 'AAPL', visible: false })
+    expect(ghost).toEqual({
+      status: 200,
+      payload: { ok: true, instances: [{ id: 'td9', params: { count: 9 }, hiddenScopes: ['hk'] }] },
+    })
+
+    // visible 缺 market → 业务拒绝
+    const noMarket = await dispatchBridgeRequest(bridge, 'PUT', '/chart/indicators', new URLSearchParams(),
+      { id: 'td9', visible: true })
+    expect(noMarket).toMatchObject({ status: 200, payload: { ok: false, code: 'TRADING_INVALID_SCOPE' } })
+  })
+
+  it('POST import 保真 hiddenScopes（symbol visibility 迁移不丢隐藏）', async () => {
+    const bridge = new TradingBridge(fakeHost())
+    await dispatchBridgeRequest(bridge, 'POST', '/chart/indicators/import', new URLSearchParams(), {
+      instances: [{ id: 'td9', params: { count: 9 }, hiddenScopes: ['us', 'hk:00700.HK', ' ', 42] }],
+    })
+    const list = await dispatchBridgeRequest(bridge, 'GET', '/chart/indicators', new URLSearchParams())
+    expect(list).toEqual({
+      status: 200,
+      payload: { ok: true, instances: [{ id: 'td9', params: { count: 9 }, hiddenScopes: ['us', 'hk:00700.HK'] }] },
+    })
+  })
+
   it('POST import 保真 symbolParams（issue #72 迁移不丢覆盖）', async () => {
     const bridge = new TradingBridge(fakeHost())
     await dispatchBridgeRequest(bridge, 'POST', '/chart/indicators/import', new URLSearchParams(), {

--- a/packages/client-ui-trading/test/chart-state.test.ts
+++ b/packages/client-ui-trading/test/chart-state.test.ts
@@ -60,6 +60,30 @@ describe('chart-state store', () => {
     })
   })
 
+  it('setSymbolVisibility：symbol 级隐藏/显示，其它标的与全局 params 不受影响（symbol visibility）', () => {
+    const store = makeStore()
+    // 隐藏当前标的：实例保留，仅 hiddenScopes 记录
+    store.setSymbolVisibility('ma', 'us', 'AAPL', false)
+    expect(store.instanceFor('ma')).toEqual({
+      id: 'ma',
+      params: { n1: 5, n2: 10, n3: 20, n4: 30, n5: 60, n6: 120 },
+      hiddenScopes: ['us:AAPL'],
+    })
+    expect(store.isActive('ma')).toBe(true)
+    // 追加另一标的隐藏 → 再显示第一个：只清该标的，其余保留
+    store.setSymbolVisibility('ma', 'hk', '00700.HK', false)
+    store.setSymbolVisibility('ma', 'us', 'AAPL', true)
+    expect(store.instanceFor('ma')?.hiddenScopes).toEqual(['hk:00700.HK'])
+    // 逐个清空后字段整体消失
+    store.setSymbolVisibility('ma', 'hk', '00700.HK', true)
+    expect(store.instanceFor('ma')).toEqual({
+      id: 'ma', params: { n1: 5, n2: 10, n3: 20, n4: 30, n5: 60, n6: 120 },
+    })
+    // 未激活 id：静默 no-op
+    store.setSymbolVisibility('rsi', 'us', 'AAPL', false)
+    expect(store.isActive('rsi')).toBe(false)
+  })
+
   it('未知 id 的 toggle/setParams 为无 default/clamp 原样落盘（防御手改 localStorage）', () => {
     const store = makeStore()
     store.togglePreset('ghost')

--- a/packages/client-ui-trading/test/quote-stage.smoke.test.tsx
+++ b/packages/client-ui-trading/test/quote-stage.smoke.test.tsx
@@ -56,6 +56,8 @@ function quoteStageProps(market: 'crypto' | 'us') {
     useChart: <T,>(sel: (state: ChartState) => T): T => sel(chart),
     toggleIndicator: () => {},
     setIndicatorParams: () => {},
+    setIndicatorVisible: () => {},
+    removeIndicator: () => {},
     deleteIndicator: async () => true,
   }
 }

--- a/packages/indicators/src/chart-activations.ts
+++ b/packages/indicators/src/chart-activations.ts
@@ -58,12 +58,26 @@ function sanitizeSymbolParams(raw: unknown): Record<string, Record<string, numbe
   return Object.keys(out).length > 0 ? out : undefined
 }
 
-/** 深拷贝规范化一个实例（params/symbolParams 均脱引用）；坏形返回 undefined。 */
+/** 按标的隐藏表防御性清洗：只留非空字符串并去重；空表返回 undefined（字段整体消失）。 */
+function sanitizeHiddenScopes(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const out: string[] = []
+  for (const item of raw) {
+    if (typeof item !== 'string') continue
+    const key = item.trim()
+    if (key !== '' && !out.includes(key)) out.push(key)
+  }
+  return out.length > 0 ? out : undefined
+}
+
+/** 深拷贝规范化一个实例（params/symbolParams/hiddenScopes 均脱引用）；坏形返回 undefined。 */
 export function sanitizeInstance(raw: unknown): IndicatorInstance | undefined {
   if (!isValidInstance(raw)) return undefined
   const params = { ...(raw.params as Record<string, number>) }
   const symbolParams = sanitizeSymbolParams((raw as { symbolParams?: unknown }).symbolParams)
-  return symbolParams !== undefined ? { id: raw.id, params, symbolParams } : { id: raw.id, params }
+  const hiddenScopes = sanitizeHiddenScopes((raw as { hiddenScopes?: unknown }).hiddenScopes)
+  const clean: IndicatorInstance = symbolParams !== undefined ? { id: raw.id, params, symbolParams } : { id: raw.id, params }
+  return hiddenScopes !== undefined ? { ...clean, hiddenScopes } : clean
 }
 
 /** 按标的覆盖的 scope 键：`${market}:${symbol}`（与 client QuoteStage 的 market/symbol 同源）。 */
@@ -87,11 +101,45 @@ export function effectiveInstanceParams(
   return instance.params
 }
 
+/**
+ * 实例对某标的的可见性：hiddenScopes 命中「market」或「${market}:${symbol}」任一
+ * 作用域即隐藏；无隐藏记录默认可见（存量名册零迁移）。market 缺失（GUI 无聚焦
+ * 标的）按可见处理——调用方此时走全局开关语义。
+ */
+export function isInstanceVisibleOn(instance: IndicatorInstance, market?: string, symbol?: string): boolean {
+  const scopes = instance.hiddenScopes
+  if (scopes === undefined || scopes.length === 0 || market === undefined) return true
+  if (scopes.includes(market)) return false
+  if (symbol !== undefined && scopes.includes(symbolScopeKey(market, symbol))) return false
+  return true
+}
+
+/**
+ * 纯函数切换实例对一个作用域（「market」或「${market}:${symbol}」）的可见性：
+ * visible=false 记隐藏（已记录则原引用返回），visible=true 清隐藏（清空后字段
+ * 整体消失；本就无记录则原引用返回）。不触碰 params/symbolParams。
+ */
+export function withHiddenScopes(instance: IndicatorInstance, scope: string, visible: boolean): IndicatorInstance {
+  const scopes = instance.hiddenScopes ?? []
+  if (!visible) {
+    return scopes.includes(scope) ? instance : { ...instance, hiddenScopes: [...scopes, scope] }
+  }
+  const next = scopes.filter(key => key !== scope)
+  if (next.length === scopes.length) return instance
+  if (next.length === 0) {
+    const rest = { ...instance }
+    delete rest.hiddenScopes
+    return rest
+  }
+  return { ...instance, hiddenScopes: next }
+}
+
 /** 内存版激活名册存储（纯浏览器与单测用）。 */
 export function createMemoryChartActivationStore(initial: IndicatorInstance[] = []): ChartActivationStore {
   const map = new Map<string, IndicatorInstance>()
   for (const item of initial) {
-    if (isValidInstance(item)) map.set(item.id, { id: item.id, params: { ...item.params } })
+    const clean = sanitizeInstance(item)
+    if (clean !== undefined) map.set(clean.id, clean)
   }
 
   return {

--- a/packages/indicators/src/chart-tools.ts
+++ b/packages/indicators/src/chart-tools.ts
@@ -7,7 +7,7 @@
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import type { CustomIndicatorStore } from './custom.ts'
 import type { ChartActivationStore } from './chart-activations.ts'
-import { clampActivationParams, defaultActivationInstance, resolveIndicatorSpec, symbolScopeKey } from './chart-activations.ts'
+import { clampActivationParams, defaultActivationInstance, resolveIndicatorSpec, symbolScopeKey, withHiddenScopes } from './chart-activations.ts'
 import type { IndicatorInstance } from './types.ts'
 import { presetDefinitions } from './presets.ts'
 
@@ -72,6 +72,7 @@ export function createIndicatorActivateTool(options: IndicatorActivateToolOption
       + 'Optionally pass paramsJson to override schema defaults; values are clamped to each parameter\'s min/max. '
       + 'Pass market AND symbol together to write a per-symbol parameter override (for indicators whose params are per-instrument): '
       + 'the override replaces the global params when that instrument is on the chart; other instruments keep the global params. '
+      + 'Activating with a scope also makes the indicator visible again for that instrument (clears per-symbol and per-market hides). '
       + 'Use indicator_list to discover ids and parameter schemas.',
     parameters: {
       id: {
@@ -140,9 +141,14 @@ export function createIndicatorActivateTool(options: IndicatorActivateToolOption
       if (scope !== undefined) {
         // 按标的覆盖（issue #72）：保留全局 params 与其它标的的覆盖，只写本标的这套。
         // 新实例的全局 params 取 schema 默认值——首个标的的覆盖不得泄漏成全局值。
+        // 显示语义：写覆盖同时清除该标的两级隐藏（symbol 级 + market 级）。
         const existing = (await chartStore.list()).find(candidate => candidate.id === id)
-        const base: IndicatorInstance = existing ?? { id, params: clampActivationParams(spec.params, {}) }
-        instance = { id, params: base.params, symbolParams: { ...(base.symbolParams ?? {}), [scope]: params } }
+        const base: IndicatorInstance = withHiddenScopes(
+          withHiddenScopes(existing ?? { id, params: clampActivationParams(spec.params, {}) }, scope, true),
+          market,
+          true,
+        )
+        instance = { ...base, symbolParams: { ...(base.symbolParams ?? {}), [scope]: params } }
       } else {
         // 全局写：保留已有按标的覆盖（旧行为直接整体覆盖实例会把 symbolParams 抹掉）。
         const existing = (await chartStore.list()).find(candidate => candidate.id === id)
@@ -164,17 +170,22 @@ export interface IndicatorDeactivateToolOptions {
   chartStore: ChartActivationStore
   /** 可选：摘除成功后的回调（plugin 接线 emit('chart')）。 */
   onDeleted?: (id: string, removed: boolean) => void
+  /** 可选：按标的隐藏成功后的回调（plugin 接线 emit('chart')，同 activate 写入面）。 */
+  onWritten?: (id: string) => void
 }
 
-/** indicator_deactivate：把指标从用户图上摘除（定义保留在指标库）。 */
+/** indicator_deactivate：无 scope 全局卸载；带 scope（market 或 market+symbol）按标的隐藏。 */
 export function createIndicatorDeactivateTool(options: IndicatorDeactivateToolOptions) {
-  const { chartStore, onDeleted } = options
+  const { chartStore, onDeleted, onWritten } = options
   return defineTool({
     name: 'indicator_deactivate',
     description:
-      'Unmount an indicator from the user\'s open chart (roster refreshes live over SSE). '
-      + 'This only removes the active chart instance — the indicator definition stays in the library '
+      'Unmount an indicator from the user\'s open chart, or hide it for specific markets/instruments. '
+      + 'Without market/symbol: removes the active chart instance entirely — the indicator definition stays in the library '
       + '(use indicator_delete to remove a custom indicator definition entirely). '
+      + 'With market (optionally plus symbol): the instance stays active but is hidden for that whole market '
+      + '(e.g. hide an HK/CN-only indicator on us and crypto) or just that one instrument — '
+      + 'other scopes keep rendering it; indicator_activate with the same market+symbol shows it again. '
       + 'Use indicator_list to see the currently active roster.',
     parameters: {
       id: {
@@ -182,16 +193,50 @@ export function createIndicatorDeactivateTool(options: IndicatorDeactivateToolOp
         required: true,
         description: 'Indicator id to unmount from the chart',
       },
+      market: {
+        type: 'string',
+        description: 'Optional market slug (crypto | us | cn | hk). With market: hide instead of unmount — hides every instrument of that market.',
+      },
+      symbol: {
+        type: 'string',
+        description: 'Optional market-canonical symbol (requires market): hide only this one instrument (e.g. "AAPL").',
+      },
     },
     output: {
       schema: { type: 'string' },
       render: (_args, value) => [{ type: 'text', text: String(value) }],
     },
     async execute(raw) {
-      const args = (raw ?? {}) as { id?: unknown }
+      const args = (raw ?? {}) as { id?: unknown; market?: unknown; symbol?: unknown }
       const id = typeof args.id === 'string' ? args.id.trim() : ''
       if (!id) {
         throw new Error('indicator_deactivate: id is required')
+      }
+      const market = typeof args.market === 'string' ? args.market.trim() : ''
+      const symbol = typeof args.symbol === 'string' ? args.symbol.trim() : ''
+      if (market === '' && symbol !== '') {
+        return '[indicator_deactivate] symbol requires market — got symbol=' + JSON.stringify(symbol)
+      }
+      if (market !== '') {
+        // 按标的隐藏：实例保留在名册，仅该作用域不渲染（其余标的照常）。
+        const existing = (await chartStore.list()).find(candidate => candidate.id === id)
+        if (existing === undefined) {
+          return JSON.stringify({
+            ok: false,
+            hidden: false,
+            note: '"' + id + '" has no active chart instance — nothing to hide (mount it with indicator_activate first).',
+          })
+        }
+        const scope = symbol !== '' ? symbolScopeKey(market, symbol) : market
+        await chartStore.activate(withHiddenScopes(existing, scope, false))
+        onWritten?.(id)
+        return JSON.stringify({
+          ok: true,
+          hidden: true,
+          note: 'Hid "' + id + '" for scope ' + JSON.stringify(scope)
+            + ' — the instance stays active and other scopes keep rendering it. '
+            + 'indicator_activate with the same market+symbol shows it again.',
+        })
       }
       const removed = await chartStore.deactivate(id)
       onDeleted?.(id, removed)

--- a/packages/indicators/src/index.ts
+++ b/packages/indicators/src/index.ts
@@ -38,9 +38,11 @@ export {
   createMemoryChartActivationStore,
   defaultActivationInstance,
   effectiveInstanceParams,
+  isInstanceVisibleOn,
   resolveIndicatorSpec,
   sanitizeInstance,
   symbolScopeKey,
+  withHiddenScopes,
   type ChartActivationStore,
   type IndicatorSpecLike,
 } from './chart-activations.ts'

--- a/packages/indicators/src/types.ts
+++ b/packages/indicators/src/types.ts
@@ -72,4 +72,10 @@ export interface IndicatorInstance {
    * 锚点参数）依赖此机制；无覆盖的标的回退全局 params。
    */
   symbolParams?: Record<string, Record<string, number>>
+  /**
+   * 按标的隐藏表：作用域键为「market」（整市场，如 "us"）或「${market}:${symbol}」
+   * （单标的，如 "hk:00700.HK"）。命中的标的不渲染该实例，其余标的跟随全局激活
+   * （默认可见，存量名册零迁移）。隐藏 ≠ 取消激活：实例仍在名册，只是对该标的不可见。
+   */
+  hiddenScopes?: string[]
 }

--- a/packages/indicators/test/chart-activations.test.ts
+++ b/packages/indicators/test/chart-activations.test.ts
@@ -12,9 +12,11 @@ import {
   createMemoryChartActivationStore,
   createMemoryCustomIndicatorStore,
   effectiveInstanceParams,
+  isInstanceVisibleOn,
   resolveIndicatorSpec,
   sanitizeInstance,
   symbolScopeKey,
+  withHiddenScopes,
 } from '../src/index.js'
 import { createFileChartActivationStore } from '../src/chart-activations-fs.js'
 import { createChartActivationTools } from '../src/chart-tools.js'
@@ -122,6 +124,56 @@ describe('symbolParams 按标的参数覆盖（issue #72）', () => {
   })
 })
 
+describe('hiddenScopes 按标的隐藏（symbol visibility）', () => {
+  const hidden = { id: 'kmaster', params: { n: 9 }, hiddenScopes: ['us', 'hk:00700.HK'] }
+
+  it('sanitizeInstance：hiddenScopes 去重/丢非空串清洗，空表整字段消失', () => {
+    expect(sanitizeInstance({ id: 'k', params: {}, hiddenScopes: ['us', 'us', ' cn ', 42, ''] }))
+      .toEqual({ id: 'k', params: {}, hiddenScopes: ['us', 'cn'] })
+    expect(sanitizeInstance({ id: 'k', params: {}, hiddenScopes: [] })).toEqual({ id: 'k', params: {} })
+    expect(sanitizeInstance({ id: 'k', params: {}, hiddenScopes: 'us' })).toEqual({ id: 'k', params: {} })
+  })
+
+  it('isInstanceVisibleOn：market 级与 symbol 级命中即隐藏，无记录/market 缺失可见', () => {
+    expect(isInstanceVisibleOn(hidden, 'us', 'AAPL')).toBe(false)      // 市场级隐藏
+    expect(isInstanceVisibleOn(hidden, 'hk', '00700.HK')).toBe(false)  // 单标的隐藏
+    expect(isInstanceVisibleOn(hidden, 'hk', '02714.HK')).toBe(true)   // 同市场其它标的可见
+    expect(isInstanceVisibleOn(hidden, 'cn', '002714.SZ')).toBe(true)
+    expect(isInstanceVisibleOn(hidden)).toBe(true)                     // 无聚焦标的 → 可见（全局语义）
+    expect(isInstanceVisibleOn({ id: 'k', params: {} }, 'us', 'AAPL')).toBe(true)
+  })
+
+  it('withHiddenScopes：记隐藏/清隐藏幂等，清空后字段整体消失，不触碰 params/symbolParams', () => {
+    const base = { id: 'k', params: { n: 1 }, symbolParams: { 'us:AAPL': { n: 2 } } }
+    const once = withHiddenScopes(base, 'us', false)
+    expect(once.hiddenScopes).toEqual(['us'])
+    expect(withHiddenScopes(once, 'us', false)).toBe(once)             // 重复记隐藏 → 原引用
+    const twice = withHiddenScopes(once, 'us:AAPL', false)
+    expect(twice.hiddenScopes).toEqual(['us', 'us:AAPL'])
+    expect(withHiddenScopes(base, 'hk:00700.HK', true)).toBe(base)     // 无记录清隐藏 → 原引用
+    const unhidden = withHiddenScopes(twice, 'us', true)
+    expect(unhidden.hiddenScopes).toEqual(['us:AAPL'])
+    const cleared = withHiddenScopes(unhidden, 'us:AAPL', true)
+    expect(cleared).toEqual(base)                                      // 清空 → 字段整体消失
+  })
+
+  it('内存 store：hiddenScopes 随 activate/list 保真', async () => {
+    const store = createMemoryChartActivationStore()
+    await store.activate(hidden)
+    expect(await store.list()).toEqual([hidden])
+  })
+
+  it('文件 store：hiddenScopes 落盘读回一致', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'dsh-chart-hide-'))
+    tmpDirs.push(dir)
+    const file = path.join(dir, 'chart.json')
+    const store = createFileChartActivationStore(file)
+    await store.activate(hidden)
+    const reopened = createFileChartActivationStore(file)
+    expect(await reopened.list()).toEqual([hidden])
+  })
+})
+
 describe('createFileChartActivationStore', () => {
   it('原子写读回一致；损坏文件降级空册', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'dsh-chart-'))
@@ -222,6 +274,47 @@ describe('图表激活工具族（indicator_list / activate / deactivate）', ()
     expect(JSON.parse(String(await deactivate.execute({ id: 'boll' })))).toMatchObject({ ok: true, removed: false })
     // required 缺失由 dsh-tools 框架校验拦截（execute 内同名校验为防御性冗余）。
     await expect(deactivate.execute({})).rejects.toThrow(/missing required property/)
+  })
+
+  it('indicator_deactivate scope 隐藏：market 级 / symbol 级 / 仅 symbol 拒绝 / 未挂载 no-op（symbol visibility）', async () => {
+    const chartStore = createMemoryChartActivationStore([{ id: 'boll', params: {} }])
+    const onWritten = vi.fn()
+    const { deactivate } = createChartActivationTools({ chartStore, onWritten })
+
+    // 仅 symbol → 业务提示不写入
+    expect(String(await deactivate.execute({ id: 'boll', symbol: 'AAPL' }))).toContain('requires market')
+    expect(await chartStore.list()).toEqual([{ id: 'boll', params: {} }])
+
+    // market 级隐藏：实例保留，us 全市场不可见
+    await deactivate.execute({ id: 'boll', market: 'us' })
+    expect(await chartStore.list()).toEqual([{ id: 'boll', params: {}, hiddenScopes: ['us'] }])
+    expect(onWritten).toHaveBeenCalledWith('boll')
+
+    // symbol 级隐藏追加；同市场其它标的不受影响
+    await deactivate.execute({ id: 'boll', market: 'hk', symbol: '00700.HK' })
+    expect(await chartStore.list()).toEqual([{ id: 'boll', params: {}, hiddenScopes: ['us', 'hk:00700.HK'] }])
+
+    // 未挂载 id 隐藏 → no-op 不反向创建
+    expect(JSON.parse(String(await deactivate.execute({ id: 'ghost', market: 'us' })))).toMatchObject({ ok: false, hidden: false })
+    expect(await chartStore.list()).toHaveLength(1)
+  })
+
+  it('indicator_activate scope 写覆盖同时清该标的两级隐藏（显示语义）', async () => {
+    const customStore = createMemoryCustomIndicatorStore([{
+      id: 'anchor_px', title: 'AnchoredPx', pane: 'main',
+      params: [{ key: 'a1', label: '锚点1', default: 0, min: 0, max: 20991231 }],
+      computeSource: CUSTOM_SOURCE, createdAt: 1,
+    }])
+    const chartStore = createMemoryChartActivationStore([{
+      id: 'anchor_px', params: { a1: 0 }, hiddenScopes: ['us', 'hk:00700.HK'],
+    }])
+    const { activate } = createChartActivationTools({ customStore, chartStore })
+    await activate.execute({ id: 'anchor_px', market: 'hk', symbol: '00700.HK', paramsJson: '{"a1":20240102}' })
+    expect(await chartStore.list()).toEqual([{
+      id: 'anchor_px', params: { a1: 0 },
+      symbolParams: { 'hk:00700.HK': { a1: 20240102 } },
+      hiddenScopes: ['us'],   // hk 两级隐藏被清除，us 市场级隐藏保留
+    }])
   })
 
   it('emit 接线：activate/deactivate 回调经便捷工厂透传（回归：漏接导致 GUI 不实时）', async () => {


### PR DESCRIPTION
## 概要

指标激活开关从「全局联动」升级为「按标的独立开关」：自定义指标（如只适合港 A 的「K大师」）可以只在对合适的标的上显示。

## 模型

`IndicatorInstance` 增加可选 `hiddenScopes?: string[]`——作用域键两级：`market`（整市场）与 `${market}:${symbol}`（单标的）。命中任一即对该标的隐藏；无记录 = 跟随全局激活（默认可见，存量名册零迁移）。**隐藏 ≠ 取消激活**：实例仍在名册，每 id 单实例 SSOT 不变。

## 语义表

| 入口 | 语义 |
|---|---|
| GUI 复选框/快捷词条 | 当前标的开关：关=记隐藏；开=清隐藏；未挂载=全局挂载；无聚焦标的=全局开关（旧语义） |
| GUI 行内「全局移除」 | 新增，带确认；原 togglePreset 全局卸载语义 |
| `indicator_activate(id, market, symbol)` | #72 写参数覆盖 + 清该标的两级隐藏（显示+写覆盖） |
| `indicator_deactivate(id, market, symbol?)` | scope 隐藏（market 级/symbol 级）；无 scope 仍为全局卸载 |
| `PUT /chart/indicators` + `visible` | 可见性写：仅 market=整市场、market+symbol=单标的；缺席幂等 no-op；visible 缺 market 拒绝 |

## 改动面

- **@dshtrading/indicators**：`isInstanceVisibleOn`/`withHiddenScopes` 助手 + sanitize 扩展（内存/文件 store、迁移导入全链路保真）；activate/deactivate 工具扩展。
- **client-ui-trading 桥**：PUT visible 语义 + import 透传 hiddenScopes。
- **client**：chart-state `setSymbolVisibility` + host-chart-sync host-first 接管；QuoteStage `visibleInstances` 唯一过滤点（图表调度/读数行/发 Agent 快照/快捷词条/勾选态），复选框改按标的开关 + 行内「全局移除」按钮；i18n 新 key（zh/en）。

## 测试

- 新增 10 个针对性用例：sanitize/可见性助手/withHiddenScopes/store 保真（内存+文件）、deactivate 三种 scope 形态、activate 清隐藏、桥 visible 写入（symbol/market 级/缺席 no-op/缺 market 拒绝）、import 保真、chart-state setSymbolVisibility。
- 门禁：`pnpm build` / `pnpm test`（1133 过 2 跳过）/ `pnpm i18n:check` 全绿。

## 决策记录

.agents/notes/implemented/feature/2026-09-07-symbol-visibility.md（含备选方案：按标的独立名册/仅单标的粒度/复选框渐变语义的否决理由；按 owner 裁决本轮不建 issue，分支 feat/symbol-visibility）