### PR TITLE
fix(indicators,base): 指标试算超时可注入 + headless 条件禁用 web 依赖行（issue #88）

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-09-windows-trial-timeout-and-headless-boot.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-windows-trial-timeout-and-headless-boot.md
@@ -1,0 +1,35 @@
+# Agent Note: 两处既存问题修复——指标试算超时可注入 + headless 条件禁用 web 依赖行
+
+Status: implemented
+
+## Problem
+
+issue #88 登记的两处与 #86（agent 工具面）无关的既存缺陷，实施 #86 / PR #87 期间实证复现：
+
+1. **Windows CI 必现 flake**：`build-test (windows-latest, 22)` 在 `pnpm -r test` 阶段偶发红，失败点集中在 `packages/indicators/test/chart-activations.test.ts` 与 `test/validate.test.ts`，报错形态 `[indicator_author] Validation failed: 在 short 样例数据上试算执行报错: 指标试算执行超时（超过 100ms）`（另一轮表现为「re-author 后 params.a2 应为 9 实际 7」——同一根因：校验失败令工具提前返回、未重挂，测试只断言 store 状态看不出校验失败）。重跑同一 commit 即绿。
+   根因：`packages/indicators/src/validate.ts` 的 `DEFAULT_TIMEOUT_MS = 100` 是 `node:vm` `runInContext(ctx, { timeout })` 的**墙钟**超时。试算本身是 30 根 K 线的纯计算（正常微秒级），100ms 只是死循环熔断线，不是性能阈值；Windows runner 只有 2 vCPU，`pnpm -r test` 全包并行时进程被抢占，合法指标也会越过墙钟线。
+2. **`trading-dev`（headless）profile 启动失败**：`DSH_HOME=~/.dsh-trading dsh --profile trading-dev "…"` 直接抛 `dsh: 4 entries did not activate`（session-archive 缺 webServer + workspaceRegistry、im 缺 connection、usage / plugin-manager 缺 webServer）。根因：`466cbe1` 在 `packages/base/cordis.patch.yml` 新增的 4 行 npm 复用插件，其 host 半顶层 `inject` 硬依赖 web 宿主服务；`dsh-headless` 层不挂 Host / HTTP server / Web runtime，没有这些服务 → 行永久 pending → `assertEntriesActivated` 终止启动。原注释「headless 宿主 host 半 webServer 注入挂起无害」与事实相反——真正无害的是走 `ctx.inject(..., cb)` 惰性注入的 client-ui-updater 行。
+
+## Decision
+
+1. **试算超时可注入，默认值不动**：`validate.ts` 导出 `DEFAULT_TRIAL_TIMEOUT_MS = 100`（并把原常量改名为该语义名，附「熔断线非性能阈值」说明）；`validateCustomIndicator` / `validateCustomIndicatorAsync` 增加 `options.trialTimeoutMs`，`validateCustomIndicatorNode` / `createAuthorIndicatorTool` / `createGetIndicatorsTool` 逐层透传。生产默认仍是 100ms 熔断，只有测试注入 5s。
+2. **四行按宿主树条件禁用**：`cordis.patch.yml` 的 `dsh-trading-session-archive` / `-im` / `-usage` / `-plugin-manager` 各加 `disabled: !!js (...)`，判定「宿主树里是否存在服务提供方行」——`@deepseek-ai/dsh-host-webserver`（webServer）、`@deepseek-ai/dsh-workspace`（workspaceRegistry）、`@deepseek-ai/dsh-client-connection`（connection）。沿用 `dsh-trading-dynamic-capabilities` 先例（issue #62）；文件头语义从「两层」扩为「三类」，新增「条件禁用行」一节，四行注释同步纠正「挂起无害」的错误表述。
+
+## Alternatives considered
+
+- **把默认超时直接调大（如 1000ms）**：生产端指标创作遇死循环要卡 5 场景 × 1s，且墙钟阈值依旧，负载更高时照样误判——拒绝；把「该可注入的参数」当「该调大的参数」是治标。
+- **只在 Windows CI 用环境变量放宽**：`validate.ts` 是浏览器安全模块（零 Node 运行时依赖），引入 `globalThis.process?.env` 守卫会把 CI 环境语义塞进纯函数——拒绝。
+- **降低 `pnpm -r test` 并发度**：治标，且拖慢 ubuntu 两个 job——拒绝。
+- **给四行补 headless 无害降级实现 / 把 inject 改可选**：要改的是 npm 复用插件的宿主半（`@linxin666/*`、`@xmanrui/*`，非本仓代码）——不可行。
+- **直接删掉这四行**：web / 桌面宿主会失去使用统计、插件管理、会话归档、IM 四个功能——拒绝。
+- **顺手把 `packages/strategies/src/validate.ts` 同形的 `DEFAULT_TIMEOUT_MS = 100` 一并可注入**：Windows 失败点只在 indicators，无实证；按「只修测试证明的问题」留待有证据时处理（已在下方 Consequences 记为已知同形风险）。
+
+## Consequences
+
+- 实测（本机，2026-09-09）：`DSH_HOME=~/.dsh-trading dsh --profile trading-dev "Reply with exactly: ok"` 无需 `--patch` 返回 `ok`（exit 0）。
+- 实测（loader 探针，同一 `!!js` 求值路径，`ctx.loader.entries()` 直读四行有效 `disabled`）：
+  - trading-dev 树（123 行，无 webserver / workspace / connection 提供方行）：四行 `disabled=true`。
+  - trading-web 隔离副本（197 行，三个提供方行全在）：四行 `disabled=false`——web / 桌面宿主回归不倒退。
+- 测试：`packages/indicators` 6 文件 69 用例全绿，新增「trialTimeoutMs 可注入：慢试算默认判超时、放宽后通过（issue #88）」；死循环保护用例仍走默认 100ms 熔断；`pnpm build` 与 `pnpm -r test` 全绿。
+- 未改动 profile / 桌面壳 / 已安装实例：验证走独立 `DSH_HOME` 隔离副本（`/private/tmp`，APFS clone + 重指向全局宿主的 cohort 重挂），运行中的桌面实例全程未受影响。隔离副本的**服务器启动路径**在本机 CLI 下会 100% CPU 空转（无日志、不监听端口）——A/B 实证：换回未加 guard 的 origin/main 版本 `cordis.patch.yml` 现象完全相同，故属隔离副本的既有环境现象，与本变更无关；回归结论以 loader 层探针为准。
+- 已知同形风险（本次不修）：`packages/strategies/src/validate.ts:43` 与其 Node vm runner 走同一 100ms 墙钟模式，若将来出现同类 Windows flake，按本记录第 1 条同款注入 `trialTimeoutMs` 即可。

--- a/.changeset/windows-trial-timeout-headless-boot.md
+++ b/.changeset/windows-trial-timeout-headless-boot.md
@@ -1,0 +1,6 @@
+---
+"@dshtrading/indicators": patch
+"@dshtrading/base": patch
+---
+
+修复两处既存问题（issue #88）：① 指标 vm 试算超时改为可注入（默认仍是 100ms 死循环熔断线）——Windows CI（2 vCPU）上 `pnpm -r test` 全包并行时墙钟抖动会把合法指标误判为超时，测试与 CI 改注入 5s，并新增「默认判超时 / 注入后通过」回归用例，死循环保护用例仍走默认值；② `packages/base` 的四行 npm 复用插件（会话归档 / IM / 使用统计 / 插件管理）其 host 半硬依赖 webServer / workspaceRegistry / connection，headless 宿主（trading-dev、trading-all）缺服务即永久 pending、宿主启动即崩，改为按宿主树是否存在服务提供方行条件禁用——web / 桌面宿主照常启用，功能不倒退。

--- a/packages/base/cordis.patch.yml
+++ b/packages/base/cordis.patch.yml
@@ -3,7 +3,7 @@
 # 本文件只允许 insert（patch 非 insert 语义是按 id 整行替换，多市场并存会互相
 # 覆盖）；共享行一律只在本层定义一次，市场 bundle 不得 replace。
 #
-# 当前两层语义（2026-08-29 web 宿主实测修正，vendor/loader + vendor/include 源码为准）：
+# 当前三类语义（2026-08-29 web 宿主实测修正，vendor/loader + vendor/include 源码为准）：
 #   1. insert 行：dsh-trading-base-gate —— 本包的统一审批监听器插件（见 src/index.ts）：
 #      对 <market>_(place|cancel)_order 且 dryRun!==true 的工具调用返回 ask 交宿主
 #      审批面；headless 无应答者时宿主降级为 deny（fail-closed 特性）。
@@ -23,6 +23,13 @@
 #      2026-09-06-unified-trading-role-presets.md；用户层 settings 仍可覆盖）。
 #      包名解析依赖本包 dependencies 里的
 #      @deepseek-ai/dsh-agent-presets（进 profile 安装闭包，S3 坑 3）。
+#
+#   3. 条件禁用行（issue #88）：host 半硬 inject web 宿主服务（webServer /
+#      workspaceRegistry / connection）的 npm 插件行，用 `disabled: !!js (...)`
+#      按「宿主树里是否存在对应服务提供方行」开关。headless 宿主（dsh-headless
+#      层，trading-dev / trading-all）没有这些服务，缺服务的行永久 pending，
+#      assertEntriesActivated 直接终止启动（2026-09-08 实测 4 行，issue #88）。
+#      先例：dsh-trading-dynamic-capabilities（issue #62，按 cordis-host-runner 行判定）。
 #
 # 脚手架阶段遗留的 insert-only 约定不变：后续共享行（组合管理/风控工具行、
 # credentials 引用约定行 [S4]）继续追加到本文件的 insert 列表。
@@ -173,8 +180,12 @@
     # （DEFAULT_AUTO_CONFIG，需用户在设置面板显式开启），insert 不改变
     # 交易会话数据安全面。包名解析依赖本包 dependencies 里的
     # @linxin666/dsh-session-archive（进 profile 安装闭包，S3 坑 3 同款）。
+    # 行安全（issue #88）：host 半硬 inject webServer + workspaceRegistry，
+    # headless 宿主缺服务即永久 pending → 启动即崩；按提供方行条件禁用
+    # （见文件头「条件禁用行」）。
     - id: dsh-trading-session-archive
       name: '@linxin666/dsh-session-archive'
+      disabled: !!js (![...loader.entries()].some((entry) => entry.options.name === '@deepseek-ai/dsh-host-webserver') || ![...loader.entries()].some((entry) => entry.options.name === '@deepseek-ai/dsh-workspace'))
 
     # IM 机器人接入（2026-09-06，npm 复用社区插件 @xmanrui/dsh-im）：飞书/微信/
     # 钉钉/企业微信/QQ/Slack/Telegram/Discord/WhatsApp 九渠道机器人接入，
@@ -182,16 +193,19 @@
     # 浏览器半（设置 → IM机器人 配置面，section order 21，与 updater 的
     # order 20 相邻不冲突）。市场无关共享行，归 base 所有（铁律 #1）。
     # 凭据须用户在设置面板显式配置，未配置时各渠道空闲待命，insert 不改变
-    # 交易会话数据安全面；headless 宿主 host 半 webServer 注入挂起无害
-    # （client-ui-updater 同款）。包名解析依赖本包 dependencies 里的
+    # 交易会话数据安全面。包名解析依赖本包 dependencies 里的
     # @xmanrui/dsh-im（进 profile 安装闭包，S3 坑 3 同款）。^4.11.0：落地
     # 时刻 4.12/4.13 尚在 pnpm minimumReleaseAge 24h 冷却期内，caret 待其
     # 出冷却后 pnpm update 自然跟进（session-archive 同款选版纪律）。
     # 注意：本行即内置安装，勿再对 profile 执行 `dsh plugin add
     # @xmanrui/dsh-im`——其自带 patch（id xmanrui-dsh-im）会与本行重复
     # 挂载同一插件，设置面二次注册。
+    # 行安全（issue #88）：host 半硬 inject connection/credentials/typertGateway，
+    # headless 宿主缺 connection 即永久 pending → 启动即崩；按提供方行条件禁用
+    # （见文件头「条件禁用行」）。
     - id: dsh-trading-im
       name: '@xmanrui/dsh-im'
+      disabled: !!js (![...loader.entries()].some((entry) => entry.options.name === '@deepseek-ai/dsh-client-connection'))
 
     # 使用统计（2026-09-08，npm 复用 dsh-web 项目同款插件 @linxin666/dsh-usage）：
     # 单行双半：host 半（会话事件流折叠成 token 账本落 $DSH_HOME/dsh-usage/
@@ -201,12 +215,14 @@
     # 适配点：本产品不含 dsh-pet（宠物），宠物气泡默认 off（插件设置面板可随时
     # 改回 always/change，属用户可见项）；账本随 DSH_HOME=~/.dsh-trading 隔离，
     # 不污染宿主 ~/.dsh。市场无关共享行，归 base 所有（铁律 #1）。
-    # headless 宿主 host 半 webServer 注入挂起无害（client-ui-updater 同款）。
     # 包名解析依赖本包 dependencies 里的 @linxin666/dsh-usage（进 profile 安装
     # 闭包，S3 坑 3 同款）。^0.3.17：落地时刻 0.3.18 尚在 pnpm minimumReleaseAge
     # 24h 冷却期内，caret 待其出冷却后 pnpm update 自然跟进（session-archive 同款）。
+    # 行安全（issue #88）：host 半硬 inject webServer，headless 宿主缺服务即
+    # 永久 pending → 启动即崩；按提供方行条件禁用（见文件头「条件禁用行」）。
     - id: dsh-trading-usage
       name: '@linxin666/dsh-usage'
+      disabled: !!js (![...loader.entries()].some((entry) => entry.options.name === '@deepseek-ai/dsh-host-webserver'))
       config:
         bubbleMode: 'off'
 
@@ -224,8 +240,11 @@
     # （socket+Host+Origin+sec-fetch-site 四重校验，非 loopback 403）。
     # 隐私面：浏览器半每日一次匿名安装心跳到 dsh-market.com（随机
     # localStorage id + 包名，无对话数据/无 IP），详见 Agent Note。
+    # 行安全（issue #88）：host 半硬 inject webServer，headless 宿主缺服务即
+    # 永久 pending → 启动即崩；按提供方行条件禁用（见文件头「条件禁用行」）。
     - id: dsh-trading-plugin-manager
       name: '@linxin666/dsh-client-ui-plugin-manager'
+      disabled: !!js (![...loader.entries()].some((entry) => entry.options.name === '@deepseek-ai/dsh-host-webserver'))
 
     # 模型能力声明（2026-09-08，npm 复用 dsh-web 项目同款插件
     # @linxin666/dsh-client-ui-model-capabilities）：在官方「模型」设置页的

--- a/packages/indicators/src/index.ts
+++ b/packages/indicators/src/index.ts
@@ -25,6 +25,7 @@ export {
   workerComputeRunner,
   compileComputeSource,
   createSampleBars,
+  DEFAULT_TRIAL_TIMEOUT_MS,
   type ValidationResult,
   type AsyncComputeRunner,
 } from './validate.ts'

--- a/packages/indicators/src/tool.ts
+++ b/packages/indicators/src/tool.ts
@@ -8,6 +8,7 @@ import { validateCustomIndicatorNode } from './validate-node.ts'
 
 export { createFileCustomIndicatorStore } from './custom-fs.ts'
 export { validateCustomIndicatorNode, nodeVmComputeRunner } from './validate-node.ts'
+export { DEFAULT_TRIAL_TIMEOUT_MS } from './validate.ts'
 
 /** 最小行情服务面（结构类型——与 @dshtrading/api 的 MarketDataService 兼容）。 */
 export interface IndicatorsMarketDataLike {
@@ -24,6 +25,12 @@ export interface GetIndicatorsToolOptions {
   klineLimit?: number
   /** 可选：自定义指标 store（issue #33）——请求 id 非预置时从此解析（校验+编译后计算）。 */
   customStore?: CustomIndicatorStore
+  /**
+   * 可选：自定义指标重校验的 vm 试算超时（毫秒，issue #88）。
+   * 缺省 100ms（DEFAULT_TRIAL_TIMEOUT_MS）——仅作死循环熔断；CI/高负载环境下
+   * 墙钟抖动会让合法指标被误判超时，需要时由此注入放宽。
+   */
+  trialTimeoutMs?: number | undefined
 }
 
 const DEFAULT_POINTS = 30
@@ -42,7 +49,7 @@ function tail(values: ReadonlyArray<number | undefined>, n: number): Array<numbe
 }
 
 export function createGetIndicatorsTool(options: GetIndicatorsToolOptions) {
-  const { marketData, market = 'crypto', providerLabel, klineLimit = 300, customStore } = options
+  const { marketData, market = 'crypto', providerLabel, klineLimit = 300, customStore, trialTimeoutMs } = options
   return defineTool({
     name: market + '_get_indicators',
     description:
@@ -102,7 +109,7 @@ export function createGetIndicatorsTool(options: GetIndicatorsToolOptions) {
             + ' — available presets: ' + DEFAULT_INDICATOR_IDS.join(', ')
             + '; custom ids require authoring via indicator_author first')
         }
-        const result = validateCustomIndicatorNode(record)
+        const result = validateCustomIndicatorNode(record, { trialTimeoutMs })
         if (!result.ok) {
           throw new Error((market + '_get_indicators: custom indicator ') + JSON.stringify(id) + ' failed validation: ' + result.reason)
         }
@@ -144,10 +151,15 @@ export interface AuthorIndicatorToolOptions {
   chartStore?: ChartActivationStore | undefined
   /** 可选：创作即上图成功后的回调（plugin 接线 emit('chart')，GUI 实时同步）。 */
   onActivated?: (id: string) => void
+  /**
+   * 可选：vm 试算超时（毫秒，issue #88）。缺省 100ms（DEFAULT_TRIAL_TIMEOUT_MS）——
+   * 仅作死循环熔断，不是性能阈值；CI/高负载环境下墙钟抖动会让合法指标被误判超时。
+   */
+  trialTimeoutMs?: number | undefined
 }
 
 export function createAuthorIndicatorTool(options: AuthorIndicatorToolOptions) {
-  const { store, onWritten, chartStore, onActivated } = options
+  const { store, onWritten, chartStore, onActivated, trialTimeoutMs } = options
 
   return defineTool({
     name: 'indicator_author',
@@ -230,7 +242,7 @@ export function createAuthorIndicatorTool(options: AuthorIndicatorToolOptions) {
         description: typeof args.description === 'string' ? args.description.trim() : undefined,
       }
 
-      const result = validateCustomIndicatorNode(candidate)
+      const result = validateCustomIndicatorNode(candidate, { trialTimeoutMs })
       if (!result.ok) {
         return (
           `[indicator_author] Validation failed: ${result.reason}\n`

--- a/packages/indicators/src/validate-node.ts
+++ b/packages/indicators/src/validate-node.ts
@@ -1,5 +1,6 @@
 /**
- * Node.js 宿主端专用校验执行器（带 node:vm 100ms 超时熔断，拦截死循环与卡死代码）。
+ * Node.js 宿主端专用校验执行器（带 node:vm 超时熔断，拦截死循环与卡死代码；
+ * 默认 100ms，入口可经 trialTimeoutMs 注入放宽——issue #88）。
  */
 import * as vm from 'node:vm'
 import type { IndicatorOutput, Kline } from './types.ts'
@@ -43,7 +44,10 @@ export const nodeVmComputeRunner: ComputeRunner = (
   }
 }
 
-/** Node.js 宿主端校验器：自动启用 node:vm 超时熔断保护。 */
-export function validateCustomIndicatorNode(raw: unknown): ValidationResult {
-  return validateCustomIndicator(raw, { runner: nodeVmComputeRunner })
+/**
+ * Node.js 宿主端校验器：自动启用 node:vm 超时熔断保护。
+ * trialTimeoutMs 缺省用 DEFAULT_TRIAL_TIMEOUT_MS（100ms）。
+ */
+export function validateCustomIndicatorNode(raw: unknown, options?: { trialTimeoutMs?: number | undefined }): ValidationResult {
+  return validateCustomIndicator(raw, { runner: nodeVmComputeRunner, trialTimeoutMs: options?.trialTimeoutMs })
 }

--- a/packages/indicators/src/validate.ts
+++ b/packages/indicators/src/validate.ts
@@ -5,7 +5,8 @@
  * 1. 结构与参数合法性断言
  * 2. 源码体积与格式检查
  * 3. 多场景样例 K 线试算（上涨/下跌/平盘/缺口/极短序列）
- * 4. 支持可插拔 runner（Node 侧传入 nodeVmRunner 开启 100ms 超时熔断保护）
+ * 4. 支持可插拔 runner（Node 侧传入 nodeVmRunner 开启超时熔断保护，默认 100ms，
+ *    可经 trialTimeoutMs 注入放宽——issue #88：CI 高并发下 100ms 墙钟偶发误判）
  * 5. 输出形状等长断言（values.length === bars.length）
  * 6. 有限数值与 warm-up 断言（严禁 NaN/Infinity/非法类型）
  */
@@ -23,7 +24,15 @@ const PARAM_KEY_PATTERN = /^[a-zA-Z0-9_]{1,16}$/
 const MAX_SOURCE_LENGTH = 16 * 1024 // 16KB
 const MAX_PARAMS_COUNT = 8
 const RESERVED_IDS = new Set(['ma', 'ema', 'boll', 'macd', 'rsi', 'kdj'])
-const DEFAULT_TIMEOUT_MS = 100
+
+/**
+ * 试算超时默认值（毫秒）。试算本身是 30 根 K 线的纯计算，正常耗时在微秒级；
+ * 100ms 只作死循环熔断，不是性能阈值——issue #88：Windows CI（2 vCPU）上
+ * `pnpm -r test` 全包并行时进程被抢占，墙钟偶发超过 100ms 导致合法指标被误判
+ * 超时。入口（两个校验器 + validateCustomIndicatorNode + 两个工具工厂）
+ * 可注入 trialTimeoutMs 放宽；死循环保护由显式用例覆盖，不依赖本默认值。
+ */
+export const DEFAULT_TRIAL_TIMEOUT_MS = 100
 
 export type ValidationResult =
   | { ok: true; definition: IndicatorDefinition; record: CustomIndicatorRecord }
@@ -168,7 +177,7 @@ export function workerComputeRunner(
   computeSource: string,
   bars: readonly Kline[],
   params: Record<string, number>,
-  timeoutMs = 100,
+  timeoutMs = DEFAULT_TRIAL_TIMEOUT_MS,
 ): Promise<unknown> {
   if (typeof Worker === 'undefined' || typeof Blob === 'undefined' || typeof URL === 'undefined') {
     try {
@@ -349,7 +358,7 @@ function checkIndicatorTrialOutputs(outputs: unknown, barsLength: number): strin
   return undefined
 }
 
-export function validateCustomIndicator(raw: unknown, options?: { runner?: ComputeRunner }): ValidationResult {
+export function validateCustomIndicator(raw: unknown, options?: { runner?: ComputeRunner; trialTimeoutMs?: number | undefined }): ValidationResult {
   const checked = checkCustomIndicatorStructure(raw)
   if (!checked.ok) return checked
   const { id, title, pane, params, computeSource, defaultParamsMap, input } = checked
@@ -357,12 +366,13 @@ export function validateCustomIndicator(raw: unknown, options?: { runner?: Compu
   const sampleScenarios = createSampleBars()
   const scenarioNames: Array<keyof typeof sampleScenarios> = ['uptrend', 'downtrend', 'flat', 'gap', 'short']
   const runner = options?.runner ?? defaultJsRunner
+  const trialTimeoutMs = options?.trialTimeoutMs ?? DEFAULT_TRIAL_TIMEOUT_MS
 
   for (const scenario of scenarioNames) {
     const bars = sampleScenarios[scenario]
     let outputs: IndicatorOutput[]
     try {
-      outputs = runner(computeSource, bars, defaultParamsMap, DEFAULT_TIMEOUT_MS)
+      outputs = runner(computeSource, bars, defaultParamsMap, trialTimeoutMs)
     } catch (error) {
       return { ok: false, reason: `在 ${scenario} 样例数据上试算执行报错: ${String((error as { message?: string })?.message ?? error)}` }
     }
@@ -402,7 +412,7 @@ export function validateCustomIndicator(raw: unknown, options?: { runner?: Compu
  */
 export async function validateCustomIndicatorAsync(
   raw: unknown,
-  options?: { runner?: AsyncComputeRunner },
+  options?: { runner?: AsyncComputeRunner; trialTimeoutMs?: number | undefined },
 ): Promise<ValidationResult> {
   const checked = checkCustomIndicatorStructure(raw)
   if (!checked.ok) return checked
@@ -411,12 +421,13 @@ export async function validateCustomIndicatorAsync(
   const sampleScenarios = createSampleBars()
   const scenarioNames: Array<keyof typeof sampleScenarios> = ['uptrend', 'downtrend', 'flat', 'gap', 'short']
   const runner = options?.runner ?? workerComputeRunner
+  const trialTimeoutMs = options?.trialTimeoutMs ?? DEFAULT_TRIAL_TIMEOUT_MS
 
   for (const scenario of scenarioNames) {
     const bars = sampleScenarios[scenario]
     let outputs: IndicatorOutput[]
     try {
-      outputs = await runner(computeSource, bars, { ...defaultParamsMap }, DEFAULT_TIMEOUT_MS) as IndicatorOutput[]
+      outputs = await runner(computeSource, bars, { ...defaultParamsMap }, trialTimeoutMs) as IndicatorOutput[]
     } catch (error) {
       return { ok: false, reason: `在 ${scenario} 样例数据上试算执行报错: ${String((error as { message?: string })?.message ?? error)}` }
     }

--- a/packages/indicators/test/chart-activations.test.ts
+++ b/packages/indicators/test/chart-activations.test.ts
@@ -24,6 +24,10 @@ import { createAuthorIndicatorTool } from '../src/tool.js'
 
 const CUSTOM_SOURCE = '(bars) => [{ key: "close_copy", kind: "line", color: "#ff0000", values: bars.map(b => b.close) }]'
 
+// issue #88：vm 试算超时默认 100ms 只作死循环熔断；CI（2 vCPU）全包并行时
+// 墙钟抖动会让合法指标被误判超时。测试注入放宽值，死循环保护另有专门用例。
+const TEST_TRIAL_TIMEOUT_MS = 5_000
+
 const tmpDirs: string[] = []
 afterAll(async () => {
   for (const dir of tmpDirs) await rm(dir, { recursive: true, force: true })
@@ -339,7 +343,7 @@ describe('indicator_author「创作即上图」（issue #63）', () => {
   it('activate: true → 校验通过后按 schema 默认参数上图', async () => {
     const store = createMemoryCustomIndicatorStore()
     const chartStore = createMemoryChartActivationStore()
-    const tool = createAuthorIndicatorTool({ store, chartStore })
+    const tool = createAuthorIndicatorTool({ store, chartStore, trialTimeoutMs: TEST_TRIAL_TIMEOUT_MS })
     const out = String(await tool.execute({ ...AUTHOR_ARGS, activate: true }))
     expect(out).toContain('mounted on the chart')
     expect(await chartStore.list()).toEqual([{ id: 'authored_i', params: {} }])
@@ -348,7 +352,7 @@ describe('indicator_author「创作即上图」（issue #63）', () => {
   it('re-author activate:true 保留 symbolParams 并按新 schema 重 clamp（issue #72 复审：不抹覆盖、stale 覆盖不直通）', async () => {
     const store = createMemoryCustomIndicatorStore()
     const chartStore = createMemoryChartActivationStore()
-    const tool = createAuthorIndicatorTool({ store, chartStore })
+    const tool = createAuthorIndicatorTool({ store, chartStore, trialTimeoutMs: TEST_TRIAL_TIMEOUT_MS })
     const v1 = { ...AUTHOR_ARGS, paramsJson: '[{"key":"a1","label":"锚点1","default":0,"min":0,"max":20991231}]' }
 
     // v1 挂载并写一个按标的覆盖
@@ -376,11 +380,11 @@ describe('indicator_author「创作即上图」（issue #63）', () => {
   it('activate 缺省 → 不上图；chartStore 缺席 → 降级说明不失败', async () => {
     const store = createMemoryCustomIndicatorStore()
     const chartStore = createMemoryChartActivationStore()
-    const withStore = createAuthorIndicatorTool({ store, chartStore })
+    const withStore = createAuthorIndicatorTool({ store, chartStore, trialTimeoutMs: TEST_TRIAL_TIMEOUT_MS })
     expect(String(await withStore.execute({ ...AUTHOR_ARGS }))).not.toContain('mounted')
     expect(await chartStore.list()).toEqual([])
 
-    const noChart = createAuthorIndicatorTool({ store })
+    const noChart = createAuthorIndicatorTool({ store, trialTimeoutMs: TEST_TRIAL_TIMEOUT_MS })
     const out = String(await noChart.execute({ ...AUTHOR_ARGS, activate: true }))
     expect(out).toContain('no chart activation store is available')
     expect(await store.get('authored_i')).toBeDefined()
@@ -390,12 +394,12 @@ describe('indicator_author「创作即上图」（issue #63）', () => {
     const store = createMemoryCustomIndicatorStore()
     const chartStore = createMemoryChartActivationStore()
     const onActivated = vi.fn()
-    await createAuthorIndicatorTool({ store, chartStore, onActivated }).execute({ ...AUTHOR_ARGS, activate: true })
+    await createAuthorIndicatorTool({ store, chartStore, onActivated, trialTimeoutMs: TEST_TRIAL_TIMEOUT_MS }).execute({ ...AUTHOR_ARGS, activate: true })
     expect(onActivated).toHaveBeenCalledTimes(1)
     expect(onActivated).toHaveBeenCalledWith('authored_i')
 
     const silent = vi.fn()
-    await createAuthorIndicatorTool({ store, chartStore, onActivated: silent }).execute({ ...AUTHOR_ARGS, id: 'authored_ii' })
+    await createAuthorIndicatorTool({ store, chartStore, onActivated: silent, trialTimeoutMs: TEST_TRIAL_TIMEOUT_MS }).execute({ ...AUTHOR_ARGS, id: 'authored_ii' })
     expect(silent).not.toHaveBeenCalled()
   })
 })

--- a/packages/indicators/test/validate.test.ts
+++ b/packages/indicators/test/validate.test.ts
@@ -3,6 +3,11 @@ import { validateCustomIndicator, compileComputeSource } from '../src/validate.t
 import { createMemoryCustomIndicatorStore } from '../src/custom.ts'
 import { createAuthorIndicatorTool, validateCustomIndicatorNode } from '../src/tool.ts'
 
+// issue #88：vm 试算超时默认 100ms 只作死循环熔断，不是性能阈值；CI（2 vCPU）
+// 全包并行时墙钟抖动会让合法指标被误判超时。走 vm 试算的用例注入放宽值，
+// 死循环保护用例仍用默认值（超时判定本身由「trialTimeoutMs 可注入」用例覆盖）。
+const TEST_TRIAL_TIMEOUT_MS = 5_000
+
 describe('validateCustomIndicator', () => {
   it('rejects invalid structural inputs', () => {
     expect(validateCustomIndicator(null).ok).toBe(false)
@@ -75,6 +80,26 @@ describe('validateCustomIndicator', () => {
     })
     expect(res.ok).toBe(false)
     if (!res.ok) expect(res.reason).toContain('非法数值')
+  })
+
+  it('trialTimeoutMs 可注入：慢试算默认判超时、放宽后通过（issue #88）', () => {
+    const raw = {
+      id: 'slow_calc',
+      title: 'Slow',
+      pane: 'main',
+      // 150ms 墙钟忙等：超过默认 100ms 熔断线，但远低于注入的放宽值。
+      computeSource: `(bars) => {
+        const deadline = Date.now() + 150;
+        while (Date.now() < deadline) {}
+        return [{ key: 'line', kind: 'line', color: '#f00', values: bars.map(b => b.close) }];
+      }`,
+    }
+    const strict = validateCustomIndicatorNode(raw)
+    expect(strict.ok).toBe(false)
+    if (!strict.ok) expect(strict.reason).toContain('超时')
+
+    const relaxed = validateCustomIndicatorNode(raw, { trialTimeoutMs: TEST_TRIAL_TIMEOUT_MS })
+    expect(relaxed.ok).toBe(true)
   })
 
   it('rejects infinite loop in computeSource (timeout protection)', () => {
@@ -266,7 +291,7 @@ describe('validateCustomIndicator', () => {
 describe('createAuthorIndicatorTool', () => {
   it('validates and persists custom indicator through tool execute', async () => {
     const store = createMemoryCustomIndicatorStore()
-    const tool = createAuthorIndicatorTool({ store })
+    const tool = createAuthorIndicatorTool({ store, trialTimeoutMs: TEST_TRIAL_TIMEOUT_MS })
 
     // 1. 尝试传入非法代码
     const failOut = await tool.execute({


### PR DESCRIPTION
Closes #88

## 改了什么

### 1. 指标 vm 试算超时改为可注入（`packages/indicators`）

`validate.ts` 的 `DEFAULT_TIMEOUT_MS = 100` 是 `node:vm` `runInContext` 的**墙钟**超时；试算本身是 30 根 K 线的纯计算（微秒级），100ms 只是死循环熔断线。Windows runner（2 vCPU）上 `pnpm -r test` 全包并行时进程被抢占，合法指标会被误判超时（issue #88 现象：`指标试算执行超时（超过 100ms）`）。

- 导出 `DEFAULT_TRIAL_TIMEOUT_MS = 100`（默认值不变）。
- `validateCustomIndicator` / `validateCustomIndicatorAsync` 增 `options.trialTimeoutMs`；`validateCustomIndicatorNode` / `createAuthorIndicatorTool` / `createGetIndicatorsTool` 逐层透传。
- 测试注入 5s；新增回归用例「150ms 忙等源码默认判超时、注入后通过」；死循环保护用例仍走默认值。

### 2. headless 条件禁用 web 依赖行（`packages/base/cordis.patch.yml`）

`466cbe1` 新增的四行 npm 复用插件（session-archive / im / usage / plugin-manager）host 半顶层 `inject` 硬依赖 webServer / workspaceRegistry / connection；`dsh-headless` 层不挂 Host / HTTP server / Web runtime → 永久 pending → `assertEntriesActivated` 终止启动（`4 entries did not activate`）。

四行各加 `disabled: !!js (...)`：按宿主树里是否存在服务提供方行（`@deepseek-ai/dsh-host-webserver` / `@deepseek-ai/dsh-workspace` / `@deepseek-ai/dsh-client-connection`）判定，沿用 `dsh-trading-dynamic-capabilities` 先例（issue #62）。文件头语义从「两层」扩为「三类」，新增「条件禁用行」一节，并纠正四行注释里「headless 注入挂起无害」的错误表述。

## 验证

| 项 | 证据 |
|---|---|
| trading-dev 免 `--patch` 启动 | `DSH_HOME=~/.dsh-trading dsh --profile trading-dev "Reply with exactly: ok"` → `ok`（exit 0） |
| trading-dev 树四行 | loader 探针（读有效 `disabled`）：四行 `disabled=true`，树内无三个提供方行 |
| trading-web 树四行 | 隔离副本 loader 探针：四行 `disabled=false`，webserver / workspace / connection 提供方行齐全（197 行）——回归不倒退 |
| 本地门禁 | `pnpm build` / `pnpm -r test`（44 文件、1363 通过、5 skip）/ `typecheck-gate`（481 = 基线）/ `pnpm i18n:check` 全绿 |
| Windows CI | 本 PR 同一 commit 连跑 3 次 `build-test (windows-latest, 22)` |

## 备注

- 验证全程未动运行中的桌面实例与线上 profile：trading-web 的回归证据走独立 `DSH_HOME` 隔离副本（`/private/tmp`，APFS clone + cohort 重挂）。该副本的**服务器启动路径**在本机 CLI 下会 100% CPU 空转（不监听端口）；A/B 实证：换回未加 guard 的 `origin/main` 版本 patch 现象完全相同，属副本环境现象，与本变更无关。
- 已知同形风险未动：`packages/strategies/src/validate.ts` 走同一 100ms 墙钟模式，Windows 失败点无实证涉及它，按「只修测试证明的问题」留待有证据时处理（已记入 Agent Note）。
- Agent Note：`.agents/notes/implemented/bug-fix/2026-09-09-windows-trial-timeout-and-headless-boot.md`
