### PR TITLE
chore(scripts): profile 预检补版本漂移检查（trading-all 混世代启动崩的根因兜底）

### DIFF
--- a/.agents/notes/implemented/process/2026-09-04-profile-cohort-normalize-preflight-gate.md
+++ b/.agents/notes/implemented/process/2026-09-04-profile-cohort-normalize-preflight-gate.md
@@ -39,8 +39,10 @@ checkout，yaml 带 @dsh/* 死 overrides）。即 4 个 WARN 背后是 4 个无�
 4. **固化门禁 `scripts/profile-config-preflight.sh <profile>...`**（只读）：
    ① 死路径（file:/link: 目标不存在）② 身份漂移（行名 ≠ 目标目录真实包名，
    并检查 cordis.patch.yml 的历史 scope name: 行）③ 闭包缺口（依赖
-   @dshtrading/* 则 overrides 必须覆盖全部仓库包）。接入
-   `refresh-trading-web-profile.sh` 预检位，失败即中止（set -e），杜绝带病
+   @dshtrading/* 则 overrides 必须覆盖全部仓库包）④ **版本漂移**（2026-09-09
+   追加：已安装的 node_modules/@dshtrading/* 拷贝必须全体同版本——同族 fixed
+   版本下混世代只可能是局部刷新残留；递归扫描但不下钻软链目录，漂移即 exit 1）。
+   接入 `refresh-trading-web-profile.sh` 预检位，失败即中止（set -e），杜绝带病
    install。数据解析在 node 内完成（行含冒号/引号，bash 切字段会炸）。
 
 ## Consequences
@@ -57,3 +59,11 @@ checkout，yaml 带 @dsh/* 死 overrides）。即 4 个 WARN 背后是 4 个无�
 - 变更面：`scripts/profile-config-preflight.sh`（新增）、
   `scripts/refresh-trading-web-profile.sh`（预检接线）、本 note。
   profile 侧变更在 `~/.dsh`（机器状态，不进仓库）。
+- **检查 ④ 的实证来源（2026-09-09）**：`trading-all` 启动崩在两个「同根症状」
+  ——`@dshtrading/watchlist` 缺 `createMemoryWatchlistGroupsStore`（client-ui-trading
+  0.1.6 对 watchlist 0.1.5），以及 `dsh-trading-hk-dataplane-eastmoney` 重复注册
+  `cn/eastmoney`（旧 eastmoney 拷贝不认 `config.market: hk`，回落到默认 cn）。
+  该 profile 的 46 个 @dshtrading 拷贝当时是 0.1.5 / 0.1.6 混装；删拷贝重装后两条
+  症状同时消失，`dsh --profile trading-all "Reply with exactly: ok"` 返回 `ok`。
+  检查 ④ 对 5 个 profile 正常态全 OK，对人工注入的单个 0.1.5 拷贝正确 FAIL
+  （exit 1）。

--- a/scripts/profile-config-preflight.sh
+++ b/scripts/profile-config-preflight.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Profile 配置预检：在 dsh plugin install / 刷新前，抓出三类会让 profile
-# 变砖或混世代的配置漂移（2026-09-03/04 实证）：
+# Profile 配置预检：在 dsh plugin install / 刷新前，抓出四类会让 profile
+# 变砖或混世代的配置漂移（2026-09-03/04 与 2026-09-09 实证）：
 #
 #   1. 死路径 —— file:/link: 依赖指向已删除目录（@dsh 时代指向 code/dsh、
 #      link: 指向已弃用 deepseek-harness checkout，目录删除后 profile 无法
@@ -11,6 +11,11 @@
 #      workspace:^ 解析不到同侪 → install 连锁失败）。
 #   3. 闭包缺口 —— profile 依赖了 @dshtrading/* 包但 overrides 没覆盖全部
 #      仓库包（#60 给 base 加 dsh-i18n 依赖后 overrides 缺行 → install 失败）。
+#   4. 版本漂移 —— 已安装的 node_modules/@dshtrading/* 拷贝混世代（同族
+#      fixed 版本，正常只可能全体同版本）。局部刷新留下的半新半旧拷贝会让
+#      profile 组装崩：2026-09-09 trading-all 实测 0.1.5/0.1.6 混装 →
+#      client-ui-trading 找不到 watchlist 新导出 + hk 的 eastmoney 行
+#      market 配置在旧拷贝里不存在 → 重复注册 cn/eastmoney，启动即崩。
 #
 # 用法：scripts/profile-config-preflight.sh <profile> [profile ...]
 #   退出码：0 = 全部通过；1 = 存在漂移（先修再 install）。
@@ -102,6 +107,43 @@ for (const profile of profiles) {
     if (missing.length) {
       problems.push("闭包缺口: overrides 缺 " + missing.join(", "));
     }
+  }
+
+  // 检查 4：已安装 @dshtrading/* 拷贝版本必须全体一致（同族 fixed 版本）。
+  // 递归但不下钻软链目录（指向宿主核心包的 symlink 会带出无关树）。
+  const installed = new Map();
+  const collectCopies = (dir, rel) => {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (!e.isDirectory()) continue;
+      const abs = path.join(dir, e.name);
+      const relPath = rel + "/" + e.name;
+      if (e.name === "@dshtrading") {
+        let pkgs = [];
+        try { pkgs = fs.readdirSync(abs, { withFileTypes: true }); } catch { continue; }
+        for (const p of pkgs) {
+          if (!p.isDirectory()) continue;
+          try {
+            const version = JSON.parse(fs.readFileSync(path.join(abs, p.name, "package.json"), "utf8")).version;
+            if (!installed.has(version)) installed.set(version, []);
+            installed.get(version).push(relPath + "/" + p.name);
+          } catch {}
+        }
+        continue;
+      }
+      if (e.name === ".pnpm") continue;
+      collectCopies(abs, relPath);
+    }
+  };
+  collectCopies(path.join(P, "node_modules"), "node_modules");
+  if (installed.size > 1) {
+    const detail = [...installed.entries()]
+      .sort((a, b) => String(a[0]).localeCompare(String(b[0])))
+      .map(([v, paths]) => v + " x" + paths.length + "（" + paths.slice(0, 3).join(", ") + (paths.length > 3 ? ", …" : "") + "）")
+      .join(" / ");
+    problems.push("版本漂移: node_modules/@dshtrading/* 混世代 " + detail
+      + "——局部刷新残留，重装：rm -rf <profile>/node_modules/@dshtrading/* && dsh plugin --profile " + profile + " install");
   }
 
   // 检查 2b：cordis.patch.yml 的 name: 行不许指向历史 scope


### PR DESCRIPTION
跟进 #88：`trading-all`（全市场 headless 验证 profile）启动崩的两个症状同根——profile 内 `@dshtrading/*` 已安装拷贝混世代。

## 现象与根因

`dsh --profile trading-all "…"` 抛：

```
Error: failed to import loader entry dsh-trading-client-ui-trading: The requested module '@dshtrading/watchlist' does not provide an export named 'createMemoryWatchlistGroupsStore'
Error: failed to apply loader entry dsh-trading-hk-dataplane-eastmoney: [dsh-trading-market-router] duplicate market data registration: cn/eastmoney
```

两条都是「半新半旧拷贝」：client-ui-trading 0.1.6 调用了 watchlist 0.1.5 没有的新导出；hk 的 eastmoney 行配 `market: hk`，而旧 eastmoney 拷贝不认该字段 → 回落默认 cn → 与 cn 行重复注册。该 profile 的 46 个 `@dshtrading/*` 拷贝当时 0.1.5 / 0.1.6 混装（局部刷新残留）。

## 改了什么

`scripts/profile-config-preflight.sh` 补检查 ④「版本漂移」：`node_modules/@dshtrading/*` 已安装拷贝必须全体同版本（同族 fixed 版本下混世代只可能是局部刷新残留），混世代 exit 1 并给出重装命令；递归扫描但不下钻软链目录（避免带出宿主核心包树）。同步更新拥有该门禁决策的 Agent Note。

profile 侧属机器状态（不进仓库），已按文档流程重装：`rm -rf <profile>/node_modules/@dshtrading/* && dsh plugin --profile trading-all install`。

## 验证

| 项 | 证据 |
|---|---|
| trading-all 启动 | `dsh --profile trading-all "Reply with exactly: ok"` → `ok`（exit 0）；46 个拷贝全 0.1.6 |
| 检查 ④ 正常态 | trading-web / trading-dev / trading-all / spike-runner / spike-s2 全 OK |
| 检查 ④ 检出能力 | 人工把 trading-all 的 hk 拷贝版本改成 0.1.5 → `FAIL 版本漂移 …`、exit 1；还原后 exit 0 |
| 脚本语法 | `bash -n` 通过 |

## 顺带发现（不在本 PR 范围）

`spike-s1` / `spike-s3` 两个本地 spike profile 的 overrides 残留历史 scope（`@dsh-trading/client-ui-strategies`），preflight 检查 ② 报身份漂移——与本次改动无关，未动。