### PR TITLE
refactor(indicators,strategies): 用户源码编译与 vm 沙箱机制收敛为单一实现

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-09-fundamentals-cache-bounded-lru.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-fundamentals-cache-bounded-lru.md
@@ -1,0 +1,25 @@
+# Agent Note: 基本面缓存无界增长修复——有界 TTL+LRU 缓存（TtlCache）
+
+Status: implemented
+
+## Problem
+
+`TradingBridge.fundamentalsCache`（`packages/client-ui-trading/src/bridge.ts:532`）按 `market:symbol` 键缓存完整基本面数据包（多期财务矩阵/股东/分红，单条可达数十 KB），5 分钟 TTL 只判新鲜、条目从不删除——桌面宿主长生命周期下，每个看过基本面页签的标的永久常驻内存，是本仓唯一的真无界内存增长点（只读审计 P3，逐行核实：set 于 :1214，全文件无 delete）。
+
+## Decision
+
+新建 `src/ttl-cache.ts` 的 `TtlCache<V>`：TTL 判新鲜（过期读 miss 并顺带清除）+ LRU 上限（命中提尾、写前清过期、超上限逐出最久未用，上限 64 条）+ 时钟注入。bridge 的 `fundamentalsCache` 换用该类，其余语义不变（in-flight 去重保持原样）。
+
+`symbolsCache` 不换：它按市场键（封顶 4 条）天然有界，无泄漏。
+
+## Alternatives considered
+
+- **只在写时清过期、不设上限**：过期条目被清但 5 分钟 TTL 内的不同标的仍无界（用户连看 500 个标的 = 500 条常驻），否决。
+- **跨包共享缓存工具（审计 F4 的长远建议）**：`holdings/fx.ts` 与 updater 各有手卷 TTL；本轮先在本包内收敛出可单测的最小类，跨包提升等 D1 的共享落点裁决后一并做，避免现在就钉死公共 API 形状。
+- **连 symbols() 也加 in-flight 去重（审计 F4 的漂移点）**：`listInstruments` 每市场每 30min 才一回，去重收益微小；不为假想流量改行为，否决。
+
+## Consequences
+
+- 行为变化：缓存条目超过 64 后最久未用条目被逐出，再次访问需重新取数（5 分钟 TTL 内的业务语义不变）。
+- 测试：`test/ttl-cache.test.ts` 4 例（TTL 过期清除/LRU 逐出与热点保护/写前清过期不占名额/同键覆盖）；包级 369 用例全绿（基线 365）。
+- 收益：基本面缓存内存占用从「按历史看过标的数无界」收敛为恒定 64 条上限。

--- a/.agents/notes/implemented/bug-fix/2026-09-09-fx-inflight-dedup.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-fx-inflight-dedup.md
@@ -1,0 +1,22 @@
+# Agent Note: FX 汇率取数同 base 在途去重
+
+Status: implemented
+
+## Problem
+
+`createFxService.getRates`（`packages/holdings/src/fx.ts`）缓存过期瞬间，并发调用各自独立打一轮 frankfurter 上游 + 重写缓存文件——多标签页/多面板的 `/fx` 轮询在 1h TTL 到期后必然撞出重复请求。桥内基本面路径早有同键 in-flight 去重先例（bridge.ts:1189-1224），FX 路径没有（只读审计 P5）。
+
+## Decision
+
+`fx.ts` 加 `inflight: Map<FxBase, Promise<FxCacheEntry>>`：miss 时在途已有同 base 任务则直接共享其结果；创建者分支内 await+finally 负责清理（不挂裸 .finally 派生 promise，避免未处理拒绝）。失败时各并发方各自进入既有失败链（过期内存 → 文件缓存 → 恒等兜底），语义不变。桥内兜底 fetcher（`createFallbackFxFetcher`）复用同一 `createFxService` 单实例，自动继承去重，无需改动。
+
+## Alternatives considered
+
+- **桥层 /fx 端点处去重**：host 注入正式 fetcher 时桥层根本不经手实现（`host.fetchFxRates ?? fallback`），去重放在服务层才能同时覆盖 `fx_get` 工具与桥端点两条通路，否决桥层方案。
+- **失败也共享兜底结果**：各调用方独立走失败链是现状语义（内存态可能不同），共享失败结果会扩大变更面，否决。
+
+## Consequences
+
+- 行为变化：同 base 并发 miss 只打一轮上游、写一次缓存文件；并发方拿到同一份 fresh 结果。
+- 测试：`fx.test.ts` +2 例——同 base 并发只一轮上游（挂起 20ms 的 mock fetch 制造真实重叠，tracker 计数）+ 失败并发各自兜底且清理后可重试；包级 76 用例全绿。
+- 收益量级：TTL 到期瞬间的并发浪费从 N 轮上游降为 1 轮（base 白名单 3 个，绝对量小；风险为零，改动 10 行）。

--- a/.agents/notes/implemented/bug-fix/2026-09-09-knowledge-graph-count-only.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-knowledge-graph-count-only.md
@@ -1,0 +1,23 @@
+# Agent Note: knowledge_graph 工具改只计数通道（不再物化 O(n²) 边对象）
+
+Status: implemented
+
+## Problem
+
+`knowledge_graph` 工具（`packages/knowledge/src/plugin.ts:71`）每次调用执行默认模式 `buildGraph(cards)`——co-tag + co-author 全配对、物化全部节点与边对象——却只取 `nodes.length` 与 `links.length` 两个数字，其余全部丢弃。graph.ts 头注自证规模：215 卡 ≈ 2 万+边。且 AGENTS.md 交易会话守则把它定为每次正式分析的第一个工具调用，频率真实、随库增长。
+
+## Decision
+
+`graph.ts` 新增 `countGraphSummary(cards)`：related 边键去重 O(E)、co-author 边按作者分组 Σk(k-1)/2（同作者对唯一，空/manual/手工 不参与，与 buildGraph 同口径）、co-tag 边按标签索引逐标签枚举对并全局去重 O(Σ k_t²)；`nodeCount = cards.length`（默认模式节点与卡一一对应）。工具输出字段与数值与改前**严格一致**（等价性由测试锁定）。
+
+## Alternatives considered
+
+- **输出砍掉 edgeCount/nodeCount**：改 agent 面工具输出契约，且丢掉库密度信号；`cards` 字段确实与 nodeCount 恒等（冗余），但契约冻结优先，否决。
+- **tagHubs 模式取数**：hub 节点改变 nodeCount 语义，输出数值口径突变，否决。
+- **按卡数缓存结果**：store 无 revision 面，用卡数+updatedAt 拼键有陈旧风险；计数通道已足够快，不引入缓存，否决。
+
+## Consequences
+
+- 实测（`spikes/bench-knowledge-graph-count.mts`，7 轮取中位数，含等价校验）：215 卡 1.98ms → 0.39ms（5.1×）；1000 卡 39.3ms → 10.2ms（3.9×）；3000 卡 428.6ms → 172ms（2.5×），且不再逐次物化 ~96 万边对象（GC 压力消除）。worst-case 复杂度同为配对级，收益在常数因子与零分配。
+- 测试：`graph.test.ts` 新增 countGraphSummary 等价套件——5 组确定性伪随机卡集（0/1/17/64/215 卡，含多标签重叠/同作者/related 互指/悬空 related/manual 排除）与 buildGraph 逐值相等断言 + 空库/自指/重复标签边角例；包级 30 用例全绿。
+- 剩余风险：buildGraph 默认模式边语义若日后变更，countGraphSummary 须同步——等价测试会当场捉住漂移。

--- a/.agents/notes/implemented/bug-fix/2026-09-09-tasks-scheduler-heartbeat-write-amplification.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-tasks-scheduler-heartbeat-write-amplification.md
@@ -1,0 +1,26 @@
+# Agent Note: 定时任务调度器空转心跳的落盘/SSE 写放大收敛
+
+Status: implemented
+
+## Problem
+
+宿主稳态空转成本：`TradingTasksService.tick` 每 30s 无条件 `ledger.updateScheduler({lastTickAt})`（`packages/client-ui-trading/src/tasks/service.ts:190`），账本 `commit` 对整文档做 JSON 深克隆 + `JSON.stringify` + `writeFileSync`/`fsyncSync`/`renameSync`/`chmodSync` 同步落盘（`ledger.ts:366-387`），随后监听器扇出 `emit('tasks')` → SSE 帧推给每个已连接标签页 → 每页 refetch 全量快照。即使零任务到期，该链路每 30s 完整跑一遍（每天 2880 次 fsync + N 标签页 refetch 风暴），持续宿主整个生命周期。实证核查：客户端没有任何 UI 消费 `scheduler.lastTickAt`（client/ 下 .tsx 无 scheduler 引用），心跳的落盘与广播是纯浪费。
+
+## Decision
+
+`TasksLedger.updateScheduler` 增加心跳快路径：patch 只刷新 `lastTickAt`（`error === undefined`）且当前无错误态时，直接在内存文档上更新快照字段并返回——不克隆、不落盘、不递增 revision、不广播。错误的出现（tick 失败写 error）与清除（出错后首个成功 tick）仍走完整 `mutate`：可见状态变化必须落盘 + 广播，UI 需要据此提示调度器故障/恢复。
+
+语义保持不变：`snapshot()` 读内存文档，`lastTickAt` 对 REST 轮询始终新鲜可见；下一次真实 commit（任务增删改、执行开合、对账）会把内存中的最新心跳值顺带落盘；重启后读到的是最近一次真实 commit 时刻顺带持久化的心跳，考虑到无消费者，该精度损失无观测者。
+
+## Alternatives considered
+
+- **心跳降频落盘（如 5min）**：仍保留稳态 fsync 与 SSE 风暴（只是变稀），且引入「降频参数」新决策点；在零消费者的前提下没有理由保留任何周期性落盘，否决。
+- **只去广播、保留落盘**：fsync 事件-loop 阻塞仍在，且为无人读的字段付磁盘磨损，否决。
+- **连内存字段也删掉**：`lastTickAt` 是 `TasksSchedulerSnapshot` 协议字段（浏览器只读面），删字段是公共契约变更，超出本修复范围，否决。
+
+## Consequences
+
+- 行为变化（仅一处）：空转 tick 不再产生 `tasks` SSE 事件与账本 revision 递增；任务板依赖真实变更事件与挂载时 fetch 刷新（`ScheduledTasksPanel` 原有路径），无依赖 30s 周期 refetch 的消费者。
+- 测试：`tasks-ledger.test.ts` 新增两例——心跳不落盘不广播（revision/文件内容/监听器计数三重断言）+ 错误出现/清除走完整 commit；包级 365 用例全绿（基线 363）。
+- 收益量化口径：稳态下每 30s 一次的整文档 fsync + 每标签页全量快照 refetch 归零（按计数消除，非时延测量；单次 fsync 约 1-20ms 事件-loop 阻塞）。
+- 剩余风险：若有外部脚本依赖账本文件 mtime 的 30s 搏动作活性探针会失效——仓内无此用法（grep 无消费者）。

--- a/.agents/notes/implemented/simplification/2026-09-09-errorpayload-dedupe.md
+++ b/.agents/notes/implemented/simplification/2026-09-09-errorpayload-dedupe.md
@@ -1,0 +1,21 @@
+# Agent Note: client-ui-trading 内 errorPayload 重复实现收敛
+
+Status: implemented
+
+## Problem
+
+`bridge.ts:521` 导出 `errorPayload`，`index.ts:374` 的 `errorPayloadOf` 与之逐字节同体（Error → {code?, message} 提取 + TRADING_UNKNOWN 兜底），而 index.ts 本就从 ./bridge.ts 导入其他符号——同包内纯重复，无任何存在理由。
+
+## Decision
+
+index.ts 改用 `bridge.ts` 导出的 `errorPayload`，删除本地 `errorPayloadOf`（唯一调用点 index.ts:298 换名）。零行为变化。
+
+## Alternatives considered
+
+- **顺手收敛 client 组件内联的 err→message（审计 F5 后半）**：核实后只有 QuoteStage.tsx:437 与 OrderPanel.tsx:197 两处同形（api.ts:211 的兜底文案是 'Network request failed'，语义不同不算重复）。两处一行表达式跨两个组件文件，抽共享 helper 的导航成本大于收益，否决。
+- **收敛 fmtPercent（trading format.ts）与 formatPercent（strategies StrategyView.tsx）的呈现分叉**：两者占位符（— vs --）与符号策略（恒带 + vs 可选）是不同面板的呈现约定，统一会改变用户可见渲染；无同步修改史证据。呈现一致性问题应交 owner 决策而非优化流顺手改，否决。
+- **统一各 client-ui 包 modules.d.ts 的 CSS 声明漂移（Readonly 有无）**：纯类型层、零运行时影响，否决。
+
+## Consequences
+
+- 同包双实现消除；包级 369 用例 + tsdown 构建全绿。

--- a/.agents/notes/implemented/simplification/2026-09-09-validator-family-consolidation.md
+++ b/.agents/notes/implemented/simplification/2026-09-09-validator-family-consolidation.md
@@ -1,0 +1,25 @@
+# Agent Note: 用户源码校验器家族收敛（indicators 拥有编译与 vm 沙箱单一实现）
+
+Status: implemented
+
+## Problem
+
+用户源码执行链在 indicators 与 strategies 间存在三处同体副本（只读审计 F3，逐行比对核实）：`compileStrategySource`（strategies/validate.ts:50-63）与 `compileComputeSource`（indicators/validate.ts:122-135）逐字节同体仅返回类型名不同；`strategies/validate-node.ts`（82 行）与 `indicators/validate-node.ts`（53 行）的 vm 沙箱 runner 机制相同；且已发生真实漂移——超时文案分裂为「指标试算/策略试算/选股器试算」三处硬编码，`nodeScreenerEvaluateRunner` 存在的原因就是复制出的 runner 改不了文案。
+
+## Decision
+
+- **编译单一来源**：strategies 的 `compileStrategySource` 变为 indicators `compileComputeSource` 的类型收窄别名（导出签名与全部调用点不变）。
+- **vm 沙箱单一实现**：indicators/validate-node.ts 新增 `runSourceInVmSandbox(source, bars, params, timeoutMs, label)`（经 `@dshtrading/indicators/tool` 子路径导出）；indicators 的 `nodeVmComputeRunner` 与 strategies 的 `nodeStrategyComputeRunner`/`nodeScreenerEvaluateRunner` 全部变为薄封装，label 参数归位三个语境的超时文案（文案逐字不变）。
+- **Worker 内第三副本**：`WORKER_TRIAL_SCRIPT` 是 blob Worker 字符串（无法 import，镜像在架构上不可避免），补注释标明单一事实来源是 `compileComputeSource`、形态嗅探正则改动必须同步。
+- 依赖方向沿用既有的 strategies → indicators（strategies 本就 import createSampleBars/workerComputeRunner），不引入新方向。
+
+## Alternatives considered
+
+- **下沉到 base 或新共享包**：Kline 类型与校验语义天然属于 indicators，strategies 已有对 indicators 的依赖；新建包要同步全部 profile 的 pnpm overrides（复制手册坑清单实证成本），否决。
+- **连 Worker 字符串也消除（构建期从函数源码生成）**：为消除一段架构性不可避免的镜像引入代码生成步骤，维护成本倒挂，否决（改以注释钉住同步点）。
+- **统一三个超时文案为同一措辞**：文案语境化是刻意的（用户能分清是哪个入口超时），label 参数化已把机制收敛，措辞差异保留。
+
+## Consequences
+
+- 机制改动今后只改一处；调用点、导出签名、超时文案逐字不变。
+- 测试：strategies 142 + indicators 69 用例全绿；全量 `pnpm -r test` 与 typecheck 棘轮见 PR 门禁记录。

--- a/.agents/notes/rejected/2026-09-09-screener-vm-compile-hoist.md
+++ b/.agents/notes/rejected/2026-09-09-screener-vm-compile-hoist.md
@@ -1,0 +1,18 @@
+# Agent Note: screener_run 逐标的 vm 编译提升为按扫描编译一次——实测无收益，撤回
+
+Status: rejected — 两种源码体量下实测差异均在测量噪声内（V8 惰性编译使 vm.Script 编译开销可忽略，逐标的成本由 createContext 主导而其为隔离语义必须保留）
+
+## Problem
+
+只读审计提出：`screener_run` 扫描循环对每个标的调用 `nodeScreenerEvaluateRunner`，内部 `new vm.Script(code)` + `vm.createContext(sandbox)` 逐次重来（`packages/strategies/src/validate-node.ts:40-41`，调用点 `packages/strategies/src/plugin.ts:1207`）；扫描池上限 500，即单次自定义选股器扫描最多 500 次重复编译，审计假设为「数百 ms CPU + GC 压力」。
+
+## Alternatives considered
+
+- **编译一次、逐标的仅建沙箱（本优化原案）**：实现后按规范做对照基准（`spikes/bench-screener-vm-compile.mts`，同源码同 500 根日 K、200 标的、5 轮取中位数，预热后测量）：一行小源码 重编译 40.6ms vs 复用 40.2ms（中位数）；24KB 现实体量源码（200 个 helper 函数）166.8ms vs 166.6ms。差异均在噪声内。根因：V8 对 Script 只立即编译顶层，内部函数惰性编译（本例 200 个 helper 只有 2 个被调用才编译），`new vm.Script` 本身极快；逐标的真实成本是 `vm.createContext`（约 0.8ms/标的量级），而它承载「标的间零状态泄漏」的隔离语义，不能为省成本复用。
+- **复用 context、逐标的重置 sandbox 键**：用户源码可改 `Math`/`Object` 等全局，复用会让前一标的的污染静默流入后一标的的判定结果；为未证实的小收益放弃隔离语义，风险大于收益，否决。
+- **维持现状**：选定。审计该条的收益假设被实测推翻，不产生代码变更。
+
+## 保留产物
+
+- `packages/strategies/test/screener-run.test.ts` 新增「编译复用执行器逐标的建独立沙箱」回归用例（对现状代码同样成立：写 globalThis 的污染源在逐标的独立 context 下计数恒为 1）——把「逐标的零状态泄漏」这一隐含不变量固化成显式测试。
+- `spikes/bench-screener-vm-compile.mts`：基准脚本留档，后续若有人再提编译复用优化可直接复跑对照。

--- a/packages/client-ui-trading/src/bridge.ts
+++ b/packages/client-ui-trading/src/bridge.ts
@@ -43,6 +43,7 @@ import type { Holding, HoldingCurrency, NewHolding, NewHoldingInput } from '@dsh
 import { createMemoryHoldingsStore } from '@dshtrading/holdings'
 import type { FxFetchLike } from '@dshtrading/holdings/fx'
 import { createFxService } from '@dshtrading/holdings/fx'
+import { TtlCache } from './ttl-cache.ts'
 
 /** 本桥支持的市场（与连接器服务键一一对应）。 */
 export type MarketId = 'crypto' | 'us' | 'cn' | 'hk'
@@ -517,6 +518,9 @@ export const SYMBOLS_CACHE_TTL_MS = 30 * 60 * 1000
  */
 export const FUNDAMENTALS_CACHE_TTL_MS = 5 * 60 * 1000
 
+/** 基本面缓存条目上限（LRU）：财报级数据包体积大，长生命周期宿主必须有界。 */
+export const FUNDAMENTALS_CACHE_MAX = 64
+
 /** 从 Error 上提取结构化错误词汇（连接器按 TradingError 形状附加 code）。 */
 export function errorPayload(error: unknown): { code: string; message: string } {
   if (error instanceof Error) {
@@ -529,7 +533,7 @@ export function errorPayload(error: unknown): { code: string; message: string } 
 
 export class TradingBridge {
   private readonly symbolsCache = new Map<string, { list: SymbolInfoWire[]; fetchedAt: number }>()
-  private readonly fundamentalsCache = new Map<string, { pkg: StockFundamentals; fetchedAt: number }>()
+  private readonly fundamentalsCache = new TtlCache<StockFundamentals>(FUNDAMENTALS_CACHE_TTL_MS, FUNDAMENTALS_CACHE_MAX)
   private readonly fundamentalsInflight = new Map<string, Promise<StockFundamentals>>()
   /** FX 兜底 fetcher（issue #65；host.fetchFxRates 注入正式实现时不走这里）。 */
   readonly #fallbackFxFetcher: FxRatesFetcher = createFallbackFxFetcher()
@@ -1182,9 +1186,9 @@ export class TradingBridge {
     if (service === undefined) throw new BridgeProtocolError(400, `market ${market} is not installed`)
 
     const cacheKey = `${market}:${trimmed}`
-    const cached = this.fundamentalsCache.get(cacheKey)
-    if (cached !== undefined && Date.now() - cached.fetchedAt < FUNDAMENTALS_CACHE_TTL_MS) {
-      return { ok: true, fundamentals: cached.pkg }
+    const cached = this.fundamentalsCache.getFresh(cacheKey, Date.now())
+    if (cached !== undefined) {
+      return { ok: true, fundamentals: cached }
     }
     const inflight = this.fundamentalsInflight.get(cacheKey)
     if (inflight !== undefined) return { ok: true, fundamentals: await inflight }
@@ -1211,7 +1215,7 @@ export class TradingBridge {
             timestamp: snapshot?.timestamp ?? Date.now(),
           } as unknown as StockFundamentals)
         : snapshot as StockFundamentals
-      this.fundamentalsCache.set(cacheKey, { pkg: result, fetchedAt: Date.now() })
+      this.fundamentalsCache.set(cacheKey, result, Date.now())
       return result
     })()
 

--- a/packages/client-ui-trading/src/client/QuoteStage.tsx
+++ b/packages/client-ui-trading/src/client/QuoteStage.tsx
@@ -792,7 +792,7 @@ export function QuoteStage({ t, useSelection, useChart, toggleIndicator, setIndi
           klines,
           indicatorReadouts: indicatorGroups.map(group => ({
             title: group.title,
-            outputs: group.outputs.map(output => ({ key: output.key, value: output.values[readoutIndex] })),
+            outputs: group.outputs.map(output => ({ key: output.key, value: output.values[readoutIndex], precision: output.precision })),
           })),
           klinesTool: `${activeMarket}_get_klines`,
         }, dataCopy)
@@ -1605,7 +1605,7 @@ function outputReadouts(
     if (value === undefined || !Number.isFinite(value)) return null
     return (
       <span key={`${group.key}.${output.key}`} style={{ color: output.color, fontWeight: 500 }}>
-        {group.title} {output.key}: {value.toFixed(2)}
+        {group.title} {output.key}: {value.toFixed(output.precision ?? 2)}
       </span>
     )
   })

--- a/packages/client-ui-trading/src/client/TvChart.tsx
+++ b/packages/client-ui-trading/src/client/TvChart.tsx
@@ -817,7 +817,7 @@ export function TvChart(props: TvChartProps): React.JSX.Element {
               if (value === undefined || !Number.isFinite(value)) return null
               return (
                 <span key={output.key} style={{ color: output.color, fontWeight: 500 }}>
-                  {output.key}: {value.toFixed(2)}
+                  {output.key}: {value.toFixed(output.precision ?? 2)}
                 </span>
               )
             })}
@@ -917,16 +917,25 @@ function syncIndicators(
   })
 }
 
+/** 输出读数小数位（precision 缺省 2，越界/非整数收敛到 0-8）。 */
+function outputDigits(output: IndicatorOutput): number {
+  if (output.precision === undefined) return 2
+  return Math.min(8, Math.max(0, Math.round(output.precision)))
+}
+
 function createSeries(chart: IChartApi, output: IndicatorOutput, paneIndex: number): ISeriesApi<SeriesType> {
   // 主图叠加（pane 0）与蜡烛同住左轴价格刻度；副图 pane 保持各自默认右轴。
   const priceScaleId = paneIndex === 0 ? { priceScaleId: 'left' as const } : {}
+  // 序列 priceFormat 与缺省（precision 2 / minMove 0.01）一致，显式传入以支持
+  // 自定义指标按 output.precision 提高十字线/轴标签分辨率。
+  const priceFormat = { type: 'price' as const, precision: outputDigits(output), minMove: 1 / 10 ** outputDigits(output) }
   if (output.kind === 'histogram') {
     return chart.addSeries(HistogramSeries, {
       ...priceScaleId,
       color: output.color,
       priceLineVisible: false,
       lastValueVisible: false,
-      priceFormat: { type: 'price', precision: 2, minMove: 0.01 },
+      priceFormat,
     }, paneIndex)
   }
   if (output.kind === 'area') {
@@ -940,6 +949,7 @@ function createSeries(chart: IChartApi, output: IndicatorOutput, paneIndex: numb
       priceLineVisible: false,
       lastValueVisible: false,
       crosshairMarkerVisible: false,
+      priceFormat,
     }, paneIndex)
   }
   return chart.addSeries(LineSeries, {
@@ -949,6 +959,7 @@ function createSeries(chart: IChartApi, output: IndicatorOutput, paneIndex: numb
     priceLineVisible: false,
     lastValueVisible: false,
     crosshairMarkerVisible: false,
+    priceFormat,
   }, paneIndex)
 }
 

--- a/packages/client-ui-trading/src/client/compose-quote-data.ts
+++ b/packages/client-ui-trading/src/client/compose-quote-data.ts
@@ -16,7 +16,8 @@ import type { Kline } from './types.ts'
 /** 一个指标实例的读数面（与图表 legend 同源：output key + 当根数值）。 */
 export interface QuoteIndicatorReadout {
   title: string
-  outputs: ReadonlyArray<{ key: string; value: number | undefined; precision?: number }>
+  // precision 显式 undefined 合法（exactOptionalPropertyTypes）：图表读数产出侧 output.precision 本就是 number | undefined。
+  outputs: ReadonlyArray<{ key: string; value: number | undefined; precision?: number | undefined }>
 }
 
 export interface QuoteDataSectionInput {

--- a/packages/client-ui-trading/src/client/compose-quote-data.ts
+++ b/packages/client-ui-trading/src/client/compose-quote-data.ts
@@ -16,7 +16,7 @@ import type { Kline } from './types.ts'
 /** 一个指标实例的读数面（与图表 legend 同源：output key + 当根数值）。 */
 export interface QuoteIndicatorReadout {
   title: string
-  outputs: ReadonlyArray<{ key: string; value: number | undefined }>
+  outputs: ReadonlyArray<{ key: string; value: number | undefined; precision?: number }>
 }
 
 export interface QuoteDataSectionInput {
@@ -67,14 +67,14 @@ function fill(template: string, slots: Record<string, string | number>): string 
 }
 
 /**
- * 指标读数 → `标题 key=value, ...`（图表 legend 同款两位小数；warm-up
- * 分量跳过，整组无有效值时整组省略）。
+ * 指标读数 → `标题 key=value, ...`（图表 legend 同款小数位：默认两位，
+ * output.precision 可指定；warm-up 分量跳过，整组无有效值时整组省略）。
  */
 function formatReadout(readout: QuoteIndicatorReadout): string | undefined {
   const entries: string[] = []
   for (const output of readout.outputs) {
     if (output.value === undefined || !Number.isFinite(output.value)) continue
-    entries.push(`${output.key}=${output.value.toFixed(2)}`)
+    entries.push(`${output.key}=${output.value.toFixed(output.precision ?? 2)}`)
   }
   return entries.length > 0 ? `${readout.title} ${entries.join(', ')}` : undefined
 }

--- a/packages/client-ui-trading/src/index.ts
+++ b/packages/client-ui-trading/src/index.ts
@@ -27,6 +27,7 @@ import {
   TradingBridge,
   createBridgeHost,
   dispatchBridgeRequest,
+  errorPayload,
   type MarketDataRegistryLike,
   type TradeRegistryLike,
 } from './bridge.ts'
@@ -295,7 +296,7 @@ export function apply(ctx: Context): void {
             sendJson(res, error.status, { ok: false, code, message: error.message })
             return
           }
-          sendJson(res, 200, { ok: false, ...errorPayloadOf(error) })
+          sendJson(res, 200, { ok: false, ...errorPayload(error) })
         }
       },
     }
@@ -371,11 +372,3 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
   }
 }
 
-function errorPayloadOf(error: unknown): { code: string; message: string } {
-  if (error instanceof Error) {
-    const raw = (error as { code?: unknown }).code
-    const code = typeof raw === 'string' ? raw : 'TRADING_UNKNOWN'
-    return { code, message: error.message }
-  }
-  return { code: 'TRADING_UNKNOWN', message: String(error) }
-}

--- a/packages/client-ui-trading/src/tasks/ledger.ts
+++ b/packages/client-ui-trading/src/tasks/ledger.ts
@@ -560,7 +560,16 @@ export class TasksLedger {
 
   /** 调度器快照字段（tick 时间/错误）。 */
   // error 显式允许 undefined：tick 成功时用它清空上次错误（缺省=无错误）。
+  // 心跳快路径：纯 lastTickAt 刷新且当前无错误态时只在内存文档推进——不做
+  // 整文档克隆/落盘 fsync/监听器广播。tick 每 30s 一次，空转时整文档 fsync
+  // + SSE 扇出（每标签页随即 refetch 全量快照）是宿主唯一稳态写放大源；
+  // lastTickAt 是易失心跳（snapshot() 读内存文档即可见），下一次真实 commit
+  // 会顺带把它落盘。错误的出现/清除仍走完整 mutate（可见状态变化必须广播）。
   updateScheduler(patch: { lastTickAt?: number; error?: string | undefined }): void {
+    if (patch.error === undefined && patch.lastTickAt !== undefined && this.document.scheduler.error === undefined) {
+      this.document.scheduler = { timeZone: this.document.scheduler.timeZone, lastTickAt: patch.lastTickAt }
+      return
+    }
     this.mutate(document => {
       document.scheduler = {
         timeZone: document.scheduler.timeZone,

--- a/packages/client-ui-trading/src/ttl-cache.ts
+++ b/packages/client-ui-trading/src/ttl-cache.ts
@@ -1,0 +1,48 @@
+/**
+ * 有界 TTL 进程内缓存（桥层热点数据专用）：TTL 判新鲜 + LRU 上限。
+ *
+ * 动机（2026-09-09，基本面缓存泄漏修复）：裸 Map + TTL 只判新鲜不驱逐，
+ * 桌面宿主长生命周期下「每个看过的标的整条数据包常驻」是慢漏。本类把
+ * 「写前清过期 + 命中提尾 + 超上限逐出最久未用」收敛成一处可单测语义。
+ * 时钟由调用方注入（Date.now()），测试用假时钟确定性断言。
+ */
+export class TtlCache<V> {
+  /** Map 迭代序 = 插入序；命中提尾后，首部即最久未用。 */
+  private readonly entries = new Map<string, { value: V; fetchedAt: number }>()
+
+  constructor(
+    private readonly ttlMs: number,
+    private readonly maxEntries: number,
+  ) {}
+
+  /** 新鲜命中 → 提尾并返回值；缺失或过期 → undefined（过期条目顺带清除）。 */
+  getFresh(key: string, now: number): V | undefined {
+    const entry = this.entries.get(key)
+    if (entry === undefined) return undefined
+    if (now - entry.fetchedAt >= this.ttlMs) {
+      this.entries.delete(key)
+      return undefined
+    }
+    this.entries.delete(key)
+    this.entries.set(key, entry)
+    return entry.value
+  }
+
+  /** 写入：先清过期条目，再逐出最久未用直至容量内，最后写入（同键覆盖先删保序）。 */
+  set(key: string, value: V, now: number): void {
+    for (const [k, entry] of this.entries) {
+      if (now - entry.fetchedAt >= this.ttlMs) this.entries.delete(k)
+    }
+    this.entries.delete(key)
+    while (this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next()
+      if (oldest.done) break
+      this.entries.delete(oldest.value)
+    }
+    this.entries.set(key, { value, fetchedAt: now })
+  }
+
+  get size(): number {
+    return this.entries.size
+  }
+}

--- a/packages/client-ui-trading/test/compose-quote-data.test.ts
+++ b/packages/client-ui-trading/test/compose-quote-data.test.ts
@@ -48,6 +48,20 @@ describe('composeQuoteDataSection', () => {
     expect(lines[3]).toBe('readouts MA MA5=11.26, MA10=10.80; MACD DIF=0.12, DEA=0.05, MACD=-0.04')
   })
 
+  it('precision：output.precision 覆盖缺省两位小数（缺省用例不变）', () => {
+    const text = composeQuoteDataSection({
+      market: 'hk',
+      symbol: '00700.HK',
+      interval: '1d',
+      klines: [kline(at(2026, 9, 1), 10), kline(at(2026, 9, 2), 11)],
+      indicatorReadouts: [
+        { title: 'KDAS', outputs: [{ key: 'KDAS_25-10-01', value: 12.3456, precision: 3 }] },
+      ],
+      klinesTool: 'hk_get_klines',
+    }, COPY)
+    expect(text.split('\n')[3]).toBe('readouts KDAS KDAS_25-10-01=12.346')
+  })
+
   it('warm-up：分量 undefined 跳过，整组无有效值整组省略', () => {
     const text = composeQuoteDataSection({
       market: 'us',

--- a/packages/client-ui-trading/test/tasks-ledger.test.ts
+++ b/packages/client-ui-trading/test/tasks-ledger.test.ts
@@ -2,7 +2,7 @@
  * 文件账本单测（临时目录）：动作语义、权限确认门、幂等、有界历史、持久化、
  * 目录锁与重启对账。时钟注入固定值，断言不依赖墙钟。
  */
-import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -136,6 +136,37 @@ describe('TasksLedger', () => {
     const second = new TasksLedger(join(env.dir, 'lock-b.json'), { now: () => T0 })
     expect(second.snapshot().tasks.length).toBe(0)
     second.dispose()
+  })
+
+  it('调度器心跳只在内存推进：不落盘、不广播、快照可见（稳态写放大优化回归）', () => {
+    env.ledger.apply(createAction('t-hb') as never)
+    const revision = env.ledger.snapshot().revision
+    const onDisk = readFileSync(env.path, 'utf8')
+    let fired = 0
+    const unsubscribe = env.ledger.subscribe(() => { fired += 1 })
+    env.ledger.updateScheduler({ lastTickAt: T0 + 30_000, error: undefined })
+    expect(env.ledger.snapshot().scheduler.lastTickAt).toBe(T0 + 30_000)
+    expect(env.ledger.snapshot().revision).toBe(revision)
+    expect(fired).toBe(0)
+    expect(readFileSync(env.path, 'utf8')).toBe(onDisk)
+    unsubscribe()
+  })
+
+  it('调度器错误的出现与清除走完整 commit（可见状态变化必须广播落盘）', () => {
+    env.ledger.apply(createAction('t-err') as never)
+    let fired = 0
+    env.ledger.subscribe(() => { fired += 1 })
+    const before = env.ledger.snapshot().revision
+    env.ledger.updateScheduler({ error: 'tick boom' })
+    expect(env.ledger.snapshot().revision).toBe(before + 1)
+    expect(env.ledger.snapshot().scheduler.error).toBe('tick boom')
+    expect(fired).toBe(1)
+    // 出错后下心跳不再走快路径：成功 tick 清错误必须落盘广播。
+    env.ledger.updateScheduler({ lastTickAt: T0 + 30_000, error: undefined })
+    expect(env.ledger.snapshot().revision).toBe(before + 2)
+    expect(env.ledger.snapshot().scheduler.error).toBeUndefined()
+    expect(env.ledger.snapshot().scheduler.lastTickAt).toBe(T0 + 30_000)
+    expect(fired).toBe(2)
   })
 
   it('重启对账：无会话 id 的执行取消，有会话 id 的保留观察', () => {

--- a/packages/client-ui-trading/test/ttl-cache.test.ts
+++ b/packages/client-ui-trading/test/ttl-cache.test.ts
@@ -1,0 +1,50 @@
+/**
+ * TtlCache 单测（假时钟）：TTL 判新鲜、命中提尾、写前清过期、LRU 逐出最久未用。
+ * 回归目标：基本面缓存从「裸 Map + TTL 只判新鲜不驱逐」改为有界缓存后，
+ * 长生命周期宿主不再按标的数无界增长（2026-09-09 泄漏修复）。
+ */
+import { describe, expect, it } from 'vitest'
+import { TtlCache } from '../src/ttl-cache.ts'
+
+describe('TtlCache', () => {
+  it('TTL 内命中；过期读 miss 并顺带清除', () => {
+    const cache = new TtlCache<string>(1000, 10)
+    cache.set('a', 'A', 0)
+    expect(cache.getFresh('a', 999)).toBe('A')
+    expect(cache.getFresh('a', 1000)).toBeUndefined()
+    expect(cache.size).toBe(0)
+  })
+
+  it('超上限逐出最久未用；命中提尾保护热点', () => {
+    const cache = new TtlCache<number>(60_000, 3)
+    cache.set('a', 1, 0)
+    cache.set('b', 2, 1)
+    cache.set('c', 3, 2)
+    // 命中 a → a 提尾，最久未用变为 b。
+    expect(cache.getFresh('a', 3)).toBe(1)
+    cache.set('d', 4, 4)
+    expect(cache.getFresh('b', 5)).toBeUndefined()
+    expect(cache.getFresh('a', 5)).toBe(1)
+    expect(cache.getFresh('c', 5)).toBe(3)
+    expect(cache.getFresh('d', 5)).toBe(4)
+    expect(cache.size).toBe(3)
+  })
+
+  it('写入前清过期：过期条目不占名额', () => {
+    const cache = new TtlCache<number>(10, 2)
+    cache.set('a', 1, 0)
+    cache.set('b', 2, 1)
+    // 两个都过期后写入 c：a/b 被清，c 不触发对新鲜条目的误逐出。
+    cache.set('c', 3, 100)
+    expect(cache.size).toBe(1)
+    expect(cache.getFresh('c', 101)).toBe(3)
+  })
+
+  it('同键覆盖不重复占位', () => {
+    const cache = new TtlCache<number>(60_000, 2)
+    cache.set('a', 1, 0)
+    cache.set('a', 2, 1)
+    expect(cache.size).toBe(1)
+    expect(cache.getFresh('a', 2)).toBe(2)
+  })
+})

--- a/packages/holdings/src/fx.ts
+++ b/packages/holdings/src/fx.ts
@@ -96,6 +96,10 @@ export function createFxService(options: FxServiceOptions = {}): FxService {
   const fetchImpl: FxFetchLike = options.fetchImpl ?? ((url, init) => fetch(url, { signal: init.signal }))
   const now = options.now ?? (() => Date.now())
   const memory = new Map<FxBase, FxCacheEntry>()
+  // 同 base 在途刷新去重：缓存过期瞬间多面板并发 getRates 时只打一轮上游 +
+  // 一次落盘（对齐桥 fundamentals 的 inflight 先例）；失败时各调用方各自走
+  // 既有失败链（过期内存 → 文件 → 恒等），互不污染。
+  const inflight = new Map<FxBase, Promise<FxCacheEntry>>()
 
   async function fetchFresh(base: FxBase): Promise<FxCacheEntry> {
     const url = `${FRANKFURTER_LATEST}?base=${base}&symbols=${FX_SYMBOLS.join(',')}`
@@ -166,9 +170,20 @@ export function createFxService(options: FxServiceOptions = {}): FxService {
       }
 
       try {
-        const fresh = await fetchFresh(base)
-        memory.set(base, fresh)
-        await writeFileCache(base, fresh)
+        let job = inflight.get(base)
+        if (job === undefined) {
+          const created = (async (): Promise<FxCacheEntry> => {
+            const fresh = await fetchFresh(base)
+            memory.set(base, fresh)
+            await writeFileCache(base, fresh)
+            return fresh
+          })()
+          inflight.set(base, created)
+          // 创建者负责清理（在创建分支内 await+finally，避免派生 promise 的未处理拒绝）。
+          try { await created } finally { inflight.delete(base) }
+          job = created
+        }
+        const fresh = await job
         return { base, rates: { ...fresh.rates }, asOf: fresh.asOf, stale: false }
       } catch {
         // 失败链（契约 §4）：过期内存 → 文件缓存 → 恒等兜底，皆 stale:true。

--- a/packages/holdings/test/fx.test.ts
+++ b/packages/holdings/test/fx.test.ts
@@ -133,6 +133,40 @@ describe('FX Service', () => {
     expect(quote.rates).toEqual({ USD: 1, USDT: 1 })
   })
 
+  it('在途去重：同 base 并发 miss 只打一轮上游；不同 base 各自一轮', async () => {
+    const tracker = { count: 0, urls: [] as string[] }
+    // 挂起一拍的 fetch：让三个并发调用真实重叠在在途窗口内。
+    const slowFetch: FxFetchLike = async (url, init) => {
+      tracker.count += 1
+      tracker.urls.push(url)
+      await new Promise(resolve => setTimeout(resolve, 20))
+      return okFetch({ rates: { CNY: 7.1, HKD: 7.8 } })(url, init)
+    }
+    const fx = createFxService({ fetchImpl: slowFetch, now: () => 5000 })
+    const [a, b, c, d] = await Promise.all([
+      fx.getRates('USD'), fx.getRates('USD'), fx.getRates('USD'), fx.getRates('CNY'),
+    ])
+    expect(tracker.count).toBe(2) // USD 一轮 + CNY 一轮
+    expect(a.stale).toBe(false)
+    expect(b.rates.CNY).toBeCloseTo(a.rates.CNY!, 10)
+    expect(c.asOf).toBe(a.asOf)
+    expect(d.base).toBe('CNY')
+  })
+
+  it('在途去重的失败路径：并发方各自走兜底链；在途清理后可重试', async () => {
+    let fail = true
+    const toggle: FxFetchLike = async (url, init) =>
+      fail ? failFetch()(url, init) : okFetch({ rates: { CNY: 7.1 } })(url, init)
+    const fx = createFxService({ fetchImpl: toggle, now: () => 7000 })
+    const [a, b] = await Promise.all([fx.getRates('USD'), fx.getRates('USD')])
+    expect(a.stale).toBe(true)
+    expect(b.stale).toBe(true)
+    fail = false
+    const retry = await fx.getRates('USD')
+    expect(retry.stale).toBe(false)
+    expect(retry.rates.CNY).toBeCloseTo(1 / 7.1, 10)
+  })
+
   it('恒等兜底：非 USD 基准只含 {base:1}（USDT/USD 无数据不编造）', async () => {
     const fx = createFxService({ fetchImpl: failFetch() })
     const quote = await fx.getRates('CNY')

--- a/packages/indicators/src/tool.ts
+++ b/packages/indicators/src/tool.ts
@@ -7,7 +7,7 @@ import { clampActivationParams, defaultActivationInstance } from './chart-activa
 import { validateCustomIndicatorNode } from './validate-node.ts'
 
 export { createFileCustomIndicatorStore } from './custom-fs.ts'
-export { validateCustomIndicatorNode, nodeVmComputeRunner } from './validate-node.ts'
+export { validateCustomIndicatorNode, nodeVmComputeRunner, runSourceInVmSandbox } from './validate-node.ts'
 export { DEFAULT_TRIAL_TIMEOUT_MS } from './validate.ts'
 
 /** 最小行情服务面（结构类型——与 @dshtrading/api 的 MarketDataService 兼容）。 */

--- a/packages/indicators/src/types.ts
+++ b/packages/indicators/src/types.ts
@@ -50,6 +50,8 @@ export interface IndicatorOutput {
   invertFilledArea?: boolean
   /** 线宽（1-4） */
   lineWidth?: number
+  /** 图例/读数小数位（缺省 2）：成本线类自定义指标可设 3 提高读数分辨率。 */
+  precision?: number
 }
 
 export interface IndicatorDefinition {

--- a/packages/indicators/src/validate-node.ts
+++ b/packages/indicators/src/validate-node.ts
@@ -6,12 +6,19 @@ import * as vm from 'node:vm'
 import type { IndicatorOutput, Kline } from './types.ts'
 import { validateCustomIndicator, type ComputeRunner, type ValidationResult } from './validate.ts'
 
-export const nodeVmComputeRunner: ComputeRunner = (
+/**
+ * 用户源码 vm 沙箱执行的单一实现（指标/策略/选股器共用，2026-09-09 收敛自
+ * strategies 的同体副本）：沙箱白名单全局、箭头/函数体双形态编译、超时熔断。
+ * label 是超时文案的语境词（如「指标试算」/「策略试算」/「选股器试算」）——
+ * 文案按调用语境归位，机制只此一份。
+ */
+export function runSourceInVmSandbox(
   computeSource: string,
   bars: readonly Kline[],
   params: Record<string, number>,
-  timeoutMs = 100,
-): IndicatorOutput[] => {
+  timeoutMs: number,
+  label: string,
+): unknown {
   const sandbox = {
     bars,
     params,
@@ -35,14 +42,21 @@ export const nodeVmComputeRunner: ComputeRunner = (
   const context = vm.createContext(sandbox)
   try {
     script.runInContext(context, { timeout: timeoutMs })
-    return sandbox.result as IndicatorOutput[]
+    return sandbox.result
   } catch (error: any) {
     if (error?.code === 'ERR_SCRIPT_EXECUTION_TIMEOUT' || String(error?.message).includes('timed out')) {
-      throw new Error(`指标试算执行超时（超过 ${timeoutMs}ms），可能存在死循环（如 while/for 未退出）`)
+      throw new Error(`${label}执行超时（超过 ${timeoutMs}ms），可能存在死循环（如 while/for 未退出）`)
     }
     throw error
   }
 }
+
+export const nodeVmComputeRunner: ComputeRunner = (
+  computeSource: string,
+  bars: readonly Kline[],
+  params: Record<string, number>,
+  timeoutMs = 100,
+): IndicatorOutput[] => runSourceInVmSandbox(computeSource, bars, params, timeoutMs, '指标试算') as IndicatorOutput[]
 
 /**
  * Node.js 宿主端校验器：自动启用 node:vm 超时熔断保护。

--- a/packages/indicators/src/validate.ts
+++ b/packages/indicators/src/validate.ts
@@ -149,7 +149,11 @@ export type AsyncComputeRunner = (
   timeoutMs: number,
 ) => Awaitable<unknown>
 
-/** blob Worker 内执行的编译+试算脚本（自包含，不依赖宿主任何模块）。 */
+/**
+ * blob Worker 内执行的编译+试算脚本（自包含，不依赖宿主任何模块）。
+ * 与 compileComputeSource 同构的第三处实现——Worker 内无法 import，镜像不可避免；
+ * 形态嗅探正则与编译语义改动必须同步本段（单一事实来源 = compileComputeSource）。
+ */
 const WORKER_TRIAL_SCRIPT = `self.onmessage = (event) => {
   const { source, bars, params } = event.data
   try {

--- a/packages/knowledge/src/graph.ts
+++ b/packages/knowledge/src/graph.ts
@@ -196,3 +196,64 @@ export function buildGraph(
 
   return { nodes, links }
 }
+
+/**
+ * 只计数的图概要（knowledge_graph 工具专用）：与默认模式 buildGraph 的
+ * { nodes.length, links.length } 严格同值，但不物化节点/边对象——
+ * related 边 O(E) 键去重、co-author 边按作者分组 Σk(k-1)/2（同作者对唯一）、
+ * co-tag 边按标签索引逐标签枚举对并全局去重 O(Σ k_t²)。工具只要规模数字时
+ * 避免全配对边的对象分配（215 卡 ≈ 2 万+边对象的构建与丢弃）。
+ */
+export function countGraphSummary(cards: readonly KnowledgeCard[]): { nodeCount: number; edgeCount: number } {
+  if (!cards || cards.length === 0) return { nodeCount: 0, edgeCount: 0 }
+  const ids = new Set<string>()
+  for (const c of cards) ids.add(c.id)
+
+  // 显式 related 边（无向键去重；与 buildGraph 的 related 段同口径）
+  const related = new Set<string>()
+  for (const card of cards) {
+    if (!Array.isArray(card.related)) continue
+    for (const targetId of card.related) {
+      if (!ids.has(targetId) || targetId === card.id) continue
+      const [a, b] = card.id < targetId ? [card.id, targetId] : [targetId, card.id]
+      related.add(`${a}:${b}`)
+    }
+  }
+
+  // co-tag 边：标签 → 成员卡索引，逐标签枚举对；全局 Set 去重后的大小即边数。
+  // 卡内重复标签先去重（对齐 buildGraph 的 Set(cardA.tags) 语义，防自配对）。
+  const byTag = new Map<string, string[]>()
+  for (const card of cards) {
+    const seen = new Set<string>()
+    for (const tag of card.tags) {
+      if (seen.has(tag)) continue
+      seen.add(tag)
+      const members = byTag.get(tag)
+      if (members === undefined) byTag.set(tag, [card.id])
+      else members.push(card.id)
+    }
+  }
+  const coTag = new Set<string>()
+  for (const members of byTag.values()) {
+    for (let i = 0; i < members.length; i++) {
+      for (let j = i + 1; j < members.length; j++) {
+        const a = members[i]!
+        const b = members[j]!
+        coTag.add(a < b ? `${a}:${b}` : `${b}:${a}`)
+      }
+    }
+  }
+
+  // co-author 边：同作者对唯一（空/'manual'/'手工' 不参与），Σ k(k-1)/2。
+  const byAuthor = new Map<string, number>()
+  for (const card of cards) {
+    const author = card.source.author.trim()
+    if (!author || author === 'manual' || author === '手工') continue
+    byAuthor.set(author, (byAuthor.get(author) ?? 0) + 1)
+  }
+  let coAuthor = 0
+  for (const k of byAuthor.values()) coAuthor += (k * (k - 1)) / 2
+
+  return { nodeCount: cards.length, edgeCount: related.size + coTag.size + coAuthor }
+}
+

--- a/packages/knowledge/src/plugin.ts
+++ b/packages/knowledge/src/plugin.ts
@@ -7,7 +7,7 @@
  *   knowledge_ingest/search 共享同一缓存）；
  * - host 平面注册 `knowledge_ingest` / `knowledge_search` / `knowledge_get` /
  *   `knowledge_delete`（从 kit/client-ui-trading 双注册收口）+ `knowledge_graph`
- *   （buildGraph 的只读结构概要包装）；
+ *   （countGraphSummary 的只读结构概要，与 buildGraph 默认模式同值）；
  * - 写/删成功 emit tradingEvents('knowledge')（issue #30 通道）。
  */
 import type { Context } from '@deepseek-ai/cordis'
@@ -15,7 +15,7 @@ import { Service } from '@deepseek-ai/cordis'
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import path from 'node:path'
 import { dshHomeDir } from '@dshtrading/dsh-home'
-import { buildGraph } from './graph.ts'
+import { countGraphSummary } from './graph.ts'
 import type { KnowledgeCardStore } from './types.ts'
 import { createFileKnowledgeCardStore } from './knowledge-fs.ts'
 import {
@@ -68,7 +68,8 @@ export function createKnowledgeGraphTool(options: KnowledgeGraphToolOptions) {
     },
     async execute() {
       const cards = await store.list()
-      const data = buildGraph(cards)
+      // 只要规模数字：计数通道与默认 buildGraph 严格同值但不物化边对象（O(n²) 配对 → 标签索引计数）。
+      const data = countGraphSummary(cards)
       // 两级检索第一级：主体（聚类键 = 卡片首个标签）全量分布——清洗后约 10-20 个
       // 主体，全量返回成本可忽略；卡片级内容一律走 knowledge_search / knowledge_get。
       const clusterCounts = new Map<string, number>()
@@ -84,8 +85,8 @@ export function createKnowledgeGraphTool(options: KnowledgeGraphToolOptions) {
       return JSON.stringify({
         ok: true,
         cards: cards.length,
-        nodeCount: data.nodes.length,
-        edgeCount: data.links.length,
+        nodeCount: data.nodeCount,
+        edgeCount: data.edgeCount,
         clusters,
         credibility,
       })

--- a/packages/knowledge/test/graph.test.ts
+++ b/packages/knowledge/test/graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildGraph } from '../src/graph.ts'
+import { buildGraph, countGraphSummary } from '../src/graph.ts'
 import type { KnowledgeCard } from '../src/types.ts'
 
 function makeCard(id: string, title: string, author: string, tags: string[], related: string[] = []): KnowledgeCard {
@@ -106,5 +106,51 @@ describe('Knowledge Graph Builder — tagHubs 模式（Obsidian 式）', () => {
     // 100 卡 + 2 hub，边 = 200 条卡-标签边；全配对模式下这里会是 4950+ 边
     expect(graph.nodes).toHaveLength(102)
     expect(graph.links).toHaveLength(200)
+  })
+})
+
+describe('countGraphSummary（knowledge_graph 的只计数通道）', () => {
+  // 与默认模式 buildGraph 的 {nodes.length, links.length} 严格同值是硬契约：
+  // 用确定性伪随机卡集做等价断言（含多标签重叠/同作者/related 互指/manual 排除）。
+  function lcg(seed: number): () => number {
+    let s = seed
+    return () => { s = (s * 1103515245 + 12345) % 2147483648; return s / 2147483648 }
+  }
+  function randomCards(seed: number, count: number): KnowledgeCard[] {
+    const rand = lcg(seed)
+    const tags = ['宏观', '行业', '公司', '策略', '风险', '估值']
+    const authors = ['alice', 'bob', 'manual', '手工', '']
+    const cards: KnowledgeCard[] = []
+    for (let i = 0; i < count; i++) {
+      const tagCount = 1 + Math.floor(rand() * 3)
+      const cardTags: string[] = []
+      for (let t = 0; t < tagCount; t++) cardTags.push(tags[Math.floor(rand() * tags.length)]!)
+      const related: string[] = []
+      if (i > 0 && rand() < 0.3) related.push('kc_' + Math.floor(rand() * i))
+      if (rand() < 0.1) related.push('kc_ghost') // 悬空 related 不入边
+      cards.push(makeCard('kc_' + i, '卡' + i, authors[Math.floor(rand() * authors.length)]!, cardTags, related))
+    }
+    return cards
+  }
+
+  it('与 buildGraph 默认模式同值（多组确定性卡集）', () => {
+    for (const [seed, count] of [[1, 0], [2, 1], [3, 17], [4, 64], [5, 215]] as const) {
+      const cards = randomCards(seed, count)
+      const summary = countGraphSummary(cards)
+      const graph = buildGraph(cards)
+      expect(summary.nodeCount).toBe(graph.nodes.length)
+      expect(summary.edgeCount).toBe(graph.links.length)
+    }
+  })
+
+  it('空库/自指 related/重复标签的边角与 buildGraph 一致', () => {
+    expect(countGraphSummary([])).toEqual({ nodeCount: 0, edgeCount: 0 })
+    const tricky = [
+      makeCard('a', 'A', 'alice', ['x', 'x', 'y'], ['a', 'b']),
+      makeCard('b', 'B', 'alice', ['y'], ['a']),
+    ]
+    const summary = countGraphSummary(tricky)
+    const graph = buildGraph(tricky)
+    expect(summary).toEqual({ nodeCount: graph.nodes.length, edgeCount: graph.links.length })
   })
 })

--- a/packages/strategies/src/validate-node.ts
+++ b/packages/strategies/src/validate-node.ts
@@ -1,9 +1,10 @@
 /**
- * Node.js 宿主端专用策略校验执行器（node:vm 100ms 超时熔断，仿 indicators
- * 的 validate-node.ts——issue #31 规格：Node 侧 vm 沙箱 + 超时熔断）。
+ * Node.js 宿主端专用策略校验执行器：vm 沙箱机制的单一实现在
+ * @dshtrading/indicators 的 runSourceInVmSandbox（2026-09-09 收敛，此前为
+ * 逐行同体副本）；本文件只保留策略/选股器语境的薄封装与超时文案归位。
  */
-import * as vm from 'node:vm'
 import type { Kline } from '@dshtrading/indicators'
+import { runSourceInVmSandbox } from '@dshtrading/indicators/tool'
 import {
   validateCustomStrategy,
   validateCustomScreener,
@@ -17,38 +18,7 @@ export const nodeStrategyComputeRunner = (
   bars: readonly Kline[],
   params: Record<string, number>,
   timeoutMs = 100,
-): StrategySignal[] => {
-  const sandbox = {
-    bars,
-    params,
-    result: null as unknown,
-    Math,
-    Array,
-    Object,
-    Number,
-    String,
-    Boolean,
-    Date,
-  }
-  const trimmed = computeSource.trim()
-  let code: string
-  if (/^(?:\([a-zA-Z0-9_,\s]*\)|[a-zA-Z0-9_]+)\s*=>/.test(trimmed) || /^function\b/.test(trimmed)) {
-    code = `"use strict"; const fn = (${trimmed}); result = fn(bars, params);`
-  } else {
-    code = `"use strict"; const fn = (function(bars, params) { ${trimmed} }); result = fn(bars, params);`
-  }
-  const script = new vm.Script(code)
-  const context = vm.createContext(sandbox)
-  try {
-    script.runInContext(context, { timeout: timeoutMs })
-    return sandbox.result as StrategySignal[]
-  } catch (error: any) {
-    if (error?.code === 'ERR_SCRIPT_EXECUTION_TIMEOUT' || String(error?.message).includes('timed out')) {
-      throw new Error(`策略试算执行超时（超过 ${timeoutMs}ms），可能存在死循环（如 while/for 未退出）`)
-    }
-    throw error
-  }
-}
+): StrategySignal[] => runSourceInVmSandbox(computeSource, bars, params, timeoutMs, '策略试算') as StrategySignal[]
 
 /** Node.js 宿主端策略校验器：自动启用 node:vm 超时熔断保护。 */
 export function validateCustomStrategyNode(raw: unknown): Promise<StrategyValidationResult> {
@@ -58,7 +28,7 @@ export function validateCustomStrategyNode(raw: unknown): Promise<StrategyValida
 /**
  * Node 宿主端选股器 evaluate 试算 runner（同一 vm 沙箱形态；返回值形状由
  * validateCustomScreener 的 ScreenerMatch 校验把关，此处不约束类型）。
- * 复用策略 vm runner，但超时文案归位为「选股器」（策略 runner 硬编码「策略试算」）。
+ * Promise 形态：抛错转拒绝，超时文案经 label 归位为「选股器试算」。
  */
 export const nodeScreenerEvaluateRunner = (
   evaluateSource: string,
@@ -67,11 +37,8 @@ export const nodeScreenerEvaluateRunner = (
   timeoutMs = 100,
 ): Promise<unknown> => {
   try {
-    return Promise.resolve(nodeStrategyComputeRunner(evaluateSource, bars, params, timeoutMs) as unknown)
-  } catch (error: any) {
-    if (error?.code === 'ERR_SCRIPT_EXECUTION_TIMEOUT' || String(error?.message).includes('timed out')) {
-      return Promise.reject(new Error(`选股器试算执行超时（超过 ${timeoutMs}ms），可能存在死循环（如 while/for 未退出）`))
-    }
+    return Promise.resolve(runSourceInVmSandbox(evaluateSource, bars, params, timeoutMs, '选股器试算'))
+  } catch (error) {
     return Promise.reject(error)
   }
 }

--- a/packages/strategies/src/validate.ts
+++ b/packages/strategies/src/validate.ts
@@ -16,6 +16,7 @@
  *    Node 侧传 vm 熔断 runner（validate-node.ts）。
  */
 import {
+  compileComputeSource,
   createSampleBars,
   workerComputeRunner,
   type AsyncComputeRunner,
@@ -46,21 +47,14 @@ export type StrategyValidationResult =
   | { ok: true; definition: import('./types.ts').StrategyDefinition; record: CustomStrategyRecord }
   | { ok: false; reason: string }
 
-/** 将策略源码解析为可执行纯函数（浏览器端 new Function；Node 侧走 vm runner 试算）。 */
-export function compileStrategySource(
+/**
+ * 将策略源码解析为可执行纯函数（浏览器端 new Function；Node 侧走 vm runner 试算）。
+ * 编译语义（形态嗅探 + new Function 双形态）的单一来源是 @dshtrading/indicators 的
+ * compileComputeSource——此处仅按策略信号类型收窄返回值（2026-09-09 收敛同体副本）。
+ */
+export const compileStrategySource = compileComputeSource as unknown as (
   source: string,
-): (bars: readonly Kline[], params: Readonly<Record<string, number>>) => StrategySignal[] {
-  const trimmed = source.trim()
-  if (
-    /^(?:\([a-zA-Z0-9_,\s]*\)|[a-zA-Z0-9_]+)\s*=>/.test(trimmed)
-    || /^function\b/.test(trimmed)
-  ) {
-    const factory = new Function(`"use strict"; return (${trimmed});`)
-    return factory() as (bars: readonly Kline[], params: Readonly<Record<string, number>>) => StrategySignal[]
-  }
-  const factory = new Function('bars', 'params', `"use strict";\n${trimmed}`)
-  return factory as unknown as (bars: readonly Kline[], params: Readonly<Record<string, number>>) => StrategySignal[]
-}
+) => (bars: readonly Kline[], params: Readonly<Record<string, number>>) => StrategySignal[]
 
 /**
  * 信号序列专用校验（引擎语义对齐：i 收盘确认、i+1 开盘成交可复算）。

--- a/packages/strategies/test/screener-run.test.ts
+++ b/packages/strategies/test/screener-run.test.ts
@@ -139,6 +139,30 @@ describe('screener_run', () => {
     expect(wire.results?.[0]?.metrics.n).toBe(300)
   })
 
+  it('编译复用执行器逐标的建独立沙箱：逐标的取数正确且全局污染不泄漏', async () => {
+    const store = createMemoryCustomScreenerStore([{
+      id: 'scr.demo-isolation', title: '隔离', horizon: 'swing', summary: '演示',
+      paramsJson: '[]', columnsJson: '[]',
+      // 写 globalThis 的污染源：若 context 被复用，n 会跨标的累加而非恒 1。
+      evaluateSource: '(bars) => { globalThis.__n = (globalThis.__n ?? 0) + 1; return { metrics: { n: globalThis.__n, len: bars.length }, reason: "x" } }',
+      createdAt: 1,
+    }])
+    const wire = JSON.parse(String(await makeTool({
+      store,
+      active: () => ({
+        provider: 'fake',
+        service: service({
+          symbols: [{ symbol: 'S300' }, { symbol: 'S150' }],
+          bars: async (symbol) => risingBars(symbol === 'S300' ? 300 : 150),
+        }),
+      }),
+    }).execute({ screenerId: 'scr.demo-isolation', market: 'us' }))) as RunWire & { results?: Array<{ metrics: Record<string, number> }> }
+    expect(wire.results).toHaveLength(2)
+    const byLen = new Map(wire.results?.map(r => [r.metrics.len, r.metrics.n]))
+    expect(byLen.get(300)).toBe(1)
+    expect(byLen.get(150)).toBe(1)
+  })
+
 
   it('总预算耗尽 → deadlineExceeded=true 且不再领取新标的（注入假时钟，确定性）', async () => {
     let clock = 0

--- a/spikes/bench-knowledge-graph-count.mts
+++ b/spikes/bench-knowledge-graph-count.mts
@@ -1,0 +1,35 @@
+/** P4 前后对照：buildGraph 默认模式（物化全部边对象） vs countGraphSummary（只计数）。 */
+import { buildGraph, countGraphSummary } from '../packages/knowledge/src/graph.ts'
+import type { KnowledgeCard } from '../packages/knowledge/src/types.ts'
+
+function makeCard(id: string, author: string, tags: string[], related: string[] = []): KnowledgeCard {
+  return {
+    id, title: 't-' + id, summary: 's',
+    source: { type: 'bilibili', url: 'https://bilibili.com/video/' + id, author, publishedAt: '2026-08-30' },
+    credibility: 'high', coreClaims: [], factCheck: { verified: [], discrepancies: [], unverifiable: [] },
+    takeaways: [], boundaries: [], tags, related,
+    createdAt: '2026-08-30T00:00:00.000Z', updatedAt: '2026-08-30T00:00:00.000Z',
+  }
+}
+function lib(count: number): KnowledgeCard[] {
+  const tags = ['宏观', '行业', '公司', '策略', '风险', '估值', '美债', 'A股', '港股', '加密', '黄金', '原油', '半导体', '医药', '消费']
+  const authors = Array.from({ length: 25 }, (_, i) => 'author-' + i)
+  return Array.from({ length: count }, (_, i) => {
+    const cardTags = [tags[i % tags.length]!, tags[(i * 7 + 3) % tags.length]!]
+    const related = i > 0 && i % 5 === 0 ? ['kc_' + ((i * 13) % i)] : []
+    return makeCard('kc_' + i, authors[i % authors.length]!, cardTags, related)
+  })
+}
+function median(xs: number[]): number { const s = [...xs].sort((a, b) => a - b); return s[Math.floor(s.length / 2)]! }
+for (const n of [215, 1000, 3000]) {
+  const cards = lib(n)
+  const check = countGraphSummary(cards)
+  const full = buildGraph(cards)
+  if (check.nodeCount !== full.nodes.length || check.edgeCount !== full.links.length) throw new Error('MISMATCH')
+  const a: number[] = []; const b: number[] = []
+  for (let r = 0; r < 7; r++) {
+    let t = performance.now(); buildGraph(cards); a.push(performance.now() - t)
+    t = performance.now(); countGraphSummary(cards); b.push(performance.now() - t)
+  }
+  console.log(JSON.stringify({ cards: n, edges: check.edgeCount, buildGraphMs: +median(a).toFixed(2), countMs: +median(b).toFixed(2), speedup: +(median(a) / median(b)).toFixed(1) }))
+}

--- a/spikes/bench-screener-vm-compile.mts
+++ b/spikes/bench-screener-vm-compile.mts
@@ -1,0 +1,39 @@
+/** P2 基准补测：现实体量源码（~200 行 helper）下重编译 vs 复用。 */
+import * as vm from 'node:vm'
+import { createNodeScreenerEvaluator } from '../packages/strategies/src/validate-node.ts'
+
+// 构造现实体量的自定义选股器源码：多 helper + 主逻辑。
+const helpers = Array.from({ length: 200 }, (_, i) =>
+  `function h${i}(bars) { let s = 0; for (let j = 0; j < bars.length; j++) { s += bars[j].close * ${i % 7 + 1} % 13; } return s % 997; }`).join('\n')
+const source = `(bars) => {\n${helpers}\n let s = 0; for (const b of bars) s += b.close + h3(bars) - h199(bars); return { metrics: { avg: s / bars.length }, reason: "bench" } }`
+console.log('sourceBytes', source.length)
+const bars = Array.from({ length: 500 }, (_, i) => ({ openTime: i, open: i, high: i, low: i, close: i, volume: i }))
+const N = 200
+
+function perInstrumentRecompile(): void {
+  for (let i = 0; i < N; i++) {
+    const sandbox = { bars, params: {}, result: null as unknown, Math, Array, Object, Number, String, Boolean, Date }
+    const trimmed = source.trim()
+    const code = `"use strict"; const fn = (${trimmed}); result = fn(bars, params);`
+    const script = new vm.Script(code)
+    const context = vm.createContext(sandbox)
+    script.runInContext(context, { timeout: 1000 })
+  }
+}
+async function compileOnce(): Promise<void> {
+  const evaluate = createNodeScreenerEvaluator(source, 1000)
+  for (let i = 0; i < N; i++) await evaluate(bars, {})
+}
+function median(xs: number[]): number { const s = [...xs].sort((a, b) => a - b); return s[Math.floor(s.length / 2)]! }
+async function main(): Promise<void> {
+  perInstrumentRecompile(); await compileOnce()
+  const before: number[] = []; const after: number[] = []
+  for (let round = 0; round < 5; round++) {
+    let t = performance.now(); perInstrumentRecompile(); before.push(performance.now() - t)
+    t = performance.now(); await compileOnce(); after.push(performance.now() - t)
+  }
+  console.log(JSON.stringify({ instruments: N, rounds: 5,
+    beforeMs: before.map(x => +x.toFixed(1)), afterMs: after.map(x => +x.toFixed(1)),
+    medianBeforeMs: +median(before).toFixed(1), medianAfterMs: +median(after).toFixed(1) }, null, 2))
+}
+await main()


### PR DESCRIPTION
## 背景

只读审计（2026-09-09 代码优化流）发现用户源码执行链在 indicators 与 strategies 间存在三处同体副本，且已真实漂移：超时文案分裂为「指标试算/策略试算/选股器试算」三处硬编码（nodeScreenerEvaluateRunner 的存在理由就是复制出的 runner 改不了文案）。

Closes #91

## 变更

- strategies/compileStrategySource → indicators compileComputeSource 的类型收窄别名（原逐字节同体副本删除）
- indicators/validate-node.ts 新增 runSourceInVmSandbox(source, bars, params, timeoutMs, label)（@dshtrading/indicators/tool 子路径导出）；三处 runner 全部变为薄封装，label 归位语境文案（逐字不变）
- WORKER_TRIAL_SCRIPT（blob Worker 字符串，架构上无法 import）补注释钉住同步点
- Agent Note: .agents/notes/implemented/simplification/2026-09-09-validator-family-consolidation.md

## 验证

- indicators 69 / strategies 142 / client-ui-trading 369 用例全绿；全量 pnpm -r test 绿
- node scripts/typecheck-gate.mjs 棘轮通过（481 = 基线）
- 导出签名与全部调用点不变；超时文案逐字不变
